### PR TITLE
Fix type filter in attachments

### DIFF
--- a/cosomis/administrativelevels/views.py
+++ b/cosomis/administrativelevels/views.py
@@ -900,7 +900,7 @@ class AttachmentListView(PageMixin, LoginRequiredMixin, TemplateView):
 
         attachment_type: str = query_params.get('type')
         if attachment_type is not None and attachment_type is not '':
-            query = query.filter(type == attachment_type)
+            query = query.filter(type=attachment_type)
 
         task: str = query_params.get('task')
         if task is not None and task is not '':


### PR DESCRIPTION
Fix type filter in attachments

- [ ] Filter by 'photo', 'document' and 'both' in gallery pages