### PR TITLE
Commune detail and gallery view

### DIFF
--- a/cosomis/administrativelevels/models.py
+++ b/cosomis/administrativelevels/models.py
@@ -1,7 +1,5 @@
-from email.policy import default
 from django.db import models
 from cdd_client import CddClient
-from django.db.models.signals import post_save, post_delete
 from django.utils.translation import gettext_lazy as _
 
 from financial.models.bank import Bank

--- a/cosomis/administrativelevels/templates/attachments/attachments.html
+++ b/cosomis/administrativelevels/templates/attachments/attachments.html
@@ -178,8 +178,8 @@
                             </button>
                         </div>
                         {% if no_results == True %}
-                            <div>No attachments</div>
-                        {% endif %}
+                        <div>No attachments</div>
+                        {% else %}
                         <form class="form-attachment d-inline-flex">
                             {% for attachment in attachments %}
                                 {% if attachment.type == 'photo' %}
@@ -202,10 +202,11 @@
                         {% endfor %}
                         </form>
                         <div class="col-12 mt-3 p-0">
-                            <button class="download-all">
-                                Download Images
-                            </button>
+                             <button class="download-all">
+                                  Download Images
+                             </button>
                         </div>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/cosomis/administrativelevels/templates/canton/canton_detail.html
+++ b/cosomis/administrativelevels/templates/canton/canton_detail.html
@@ -1,0 +1,12 @@
+{% extends 'layouts/base.html' %}
+{% load static i18n custom_tags %}
+
+{% block extracss %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'plugins/datepicker/date-picker.css' %}" />
+{% endblock %}
+
+
+{% block content %}
+Canton
+{% endblock %}

--- a/cosomis/administrativelevels/templates/commune/commune_detail.html
+++ b/cosomis/administrativelevels/templates/commune/commune_detail.html
@@ -1,0 +1,12 @@
+{% extends 'layouts/base.html' %}
+{% load static i18n custom_tags %}
+
+{% block extracss %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'plugins/datepicker/date-picker.css' %}" />
+{% endblock %}
+
+
+{% block content %}
+Commune
+{% endblock %}

--- a/cosomis/administrativelevels/urls.py
+++ b/cosomis/administrativelevels/urls.py
@@ -12,13 +12,16 @@ urlpatterns = [
     path('update/<int:pk>/', views.AdministrativeLevelUpdateView.as_view(), name='update'), # Administrative level path to update
     path('village-detail/<int:pk>/', views.VillageDetailView.as_view(), name='village_detail'), #The path of the detail of village
     path('detail/<int:pk>/', views.AdministrativeLevelDetailView.as_view(), name='detail'), #The path of the detail
-    path('detail/<int:adm_id>/attachments/', views.AttachmentListView.as_view(), name='village_attachments'), #The path of the village attachments list
+    path('detail/<int:adm_id>/attachments/', views.VillageAttachmentListView.as_view(), name='village_attachments'), #The path of the village attachments list
     path('detail/<int:adm_id>/attachments/<path:url>/download/', views.attachment_download, name='village_attachment_download'),
     path('detail/<int:adm_id>/attachments/download-zip/', views.attachment_download_zip,
          name='village_attachment_download_zip'),
 
     path('commune/<int:pk>/', views.CommuneDetailView.as_view(), name='commune_detail'),
-    path('commune/<int:adm_id>/attachments/', views.AttachmentListView.as_view(), name='commune_attachments'),
+    path('commune/<int:adm_id>/attachments/', views.CommuneAttachmentListView.as_view(), name='commune_attachments'),
+
+    path('canton/<int:pk>/', views.CommuneDetailView.as_view(), name='commune_detail'),
+    path('canton/<int:adm_id>/attachments/', views.CantonAttachmentListView.as_view(), name='canton_attachments'),
 
     # The path of the detail of village
     path('attachments/', views.AttachmentListView.as_view(), name='attachments'), # The path of the attachments list

--- a/cosomis/administrativelevels/urls.py
+++ b/cosomis/administrativelevels/urls.py
@@ -17,6 +17,10 @@ urlpatterns = [
     path('detail/<int:adm_id>/attachments/download-zip/', views.attachment_download_zip,
          name='village_attachment_download_zip'),
 
+    path('commune/<int:pk>/', views.CommuneDetailView.as_view(), name='commune_detail'),
+    path('commune/<int:adm_id>/attachments/', views.AttachmentListView.as_view(), name='commune_attachments'),
+
+    # The path of the detail of village
     path('attachments/', views.AttachmentListView.as_view(), name='attachments'), # The path of the attachments list
 
     # The path to delete obstacle

--- a/cosomis/administrativelevels/urls.py
+++ b/cosomis/administrativelevels/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     path('commune/<int:pk>/', views.CommuneDetailView.as_view(), name='commune_detail'),
     path('commune/<int:adm_id>/attachments/', views.CommuneAttachmentListView.as_view(), name='commune_attachments'),
 
-    path('canton/<int:pk>/', views.CommuneDetailView.as_view(), name='commune_detail'),
+    path('canton/<int:pk>/', views.CantonDetailView.as_view(), name='canton_detail'),
     path('canton/<int:adm_id>/attachments/', views.CantonAttachmentListView.as_view(), name='canton_attachments'),
 
     # The path of the detail of village

--- a/cosomis/administrativelevels/views.py
+++ b/cosomis/administrativelevels/views.py
@@ -916,6 +916,18 @@ class AttachmentListView(PageMixin, LoginRequiredMixin, TemplateView):
 
         return list(query.all())
 
+class VillageAttachmentListView(AttachmentListView):
+    title = _("Galerie d'images")
+
+    def get_context_data(self, **kwargs):
+        context = super(VillageAttachmentListView, self).get_context_data(**kwargs)
+        village_exist = AdministrativeLevel.objects.filter(id=context.get("adm_id"), type="Village")
+
+        if len(village_exist) == 0:
+            raise Http404
+
+        return context
+
 @login_required
 def attachment_download(self, adm_id: int, url: str):
     response = requests.get(url)
@@ -1356,8 +1368,6 @@ class DownloadCVDCSVView(PageMixin, LoginRequiredMixin, TemplateView):
 
 # Commune
 class CommuneDetailView(PageMixin, LoginRequiredMixin, DetailView):
-    """Class to present the detail page of a commune"""
-
     model = AdministrativeLevel
     template_name = 'commune/commune_detail.html'
     context_object_name = 'commune'
@@ -1373,6 +1383,47 @@ class CommuneDetailView(PageMixin, LoginRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super(CommuneDetailView, self).get_context_data(**kwargs)
         if context.get("object") and context.get(
-                "object").type == "Commune":  # Verify if the administrativeLevel type is Village
+                "object").type == "Commune":
             return context
         raise Http404
+
+class CommuneAttachmentListView(AttachmentListView):
+    def get_context_data(self, **kwargs):
+        context = super(CommuneAttachmentListView, self).get_context_data(**kwargs)
+        commune_exist = AdministrativeLevel.objects.filter(id=context.get("adm_id"), type="Commune")
+
+        if len(commune_exist) == 0:
+            raise Http404
+
+        return context
+
+# Canton
+class CantonDetailView(PageMixin, LoginRequiredMixin, DetailView):
+    model = AdministrativeLevel
+    template_name = 'canton/canton_detail.html'
+    context_object_name = 'canton'
+    title = _('Canton')
+    active_level1 = 'administrative_levels'
+    breadcrumb = [
+        {
+            'url': '',
+            'title': title
+        },
+    ]
+
+    def get_context_data(self, **kwargs):
+        context = super(CantonDetailView, self).get_context_data(**kwargs)
+        if context.get("object") and context.get(
+                "object").type == "Canton":
+            return context
+        raise Http404
+
+class CantonAttachmentListView(AttachmentListView):
+    def get_context_data(self, **kwargs):
+        context = super(CantonAttachmentListView, self).get_context_data(**kwargs)
+        canton_exist = AdministrativeLevel.objects.filter(id=context.get("adm_id"), type="Canton")
+
+        if len(canton_exist) == 0:
+            raise Http404
+
+        return context

--- a/cosomis/administrativelevels/views.py
+++ b/cosomis/administrativelevels/views.py
@@ -1353,4 +1353,26 @@ class DownloadCVDCSVView(PageMixin, LoginRequiredMixin, TemplateView):
                 file_path,
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             )
-    
+
+# Commune
+class CommuneDetailView(PageMixin, LoginRequiredMixin, DetailView):
+    """Class to present the detail page of a commune"""
+
+    model = AdministrativeLevel
+    template_name = 'commune/commune_detail.html'
+    context_object_name = 'commune'
+    title = _('Commune')
+    active_level1 = 'administrative_levels'
+    breadcrumb = [
+        {
+            'url': '',
+            'title': title
+        },
+    ]
+
+    def get_context_data(self, **kwargs):
+        context = super(CommuneDetailView, self).get_context_data(**kwargs)
+        if context.get("object") and context.get(
+                "object").type == "Commune":  # Verify if the administrativeLevel type is Village
+            return context
+        raise Http404


### PR DESCRIPTION
This PR adds:
- Commune/Canton detail and gallery view
- Security to attachment list since now it checks if it is village, canton or commune

## How to test?

Load pages
- [ ] Check general attachment list
- [ ] Check village attachment list
- [ ] Check commune detail
- [ ] Check commune attachment
- [ ] Check canton detail
- [ ] Check canton attachment

Check security
- [ ] Navigate to a village attachment URL with a canton id, it should give 404
- [ ] Navigate to a village attachment URL with a commune id, it should give 404
- [ ] Navigate to a canton attachment URL with a commune id, it should give 404
- [ ] Navigate to a canton attachment URL with a village id, it should give 404
- [ ] Navigate to a commune attachment URL with a canton id, it should give 404
- [ ] Navigate to a commune attachment URL with a village id, it should give 404