### PR TITLE
Search page for all administrative levels

### DIFF
--- a/cosomis/administrativelevels/models.py
+++ b/cosomis/administrativelevels/models.py
@@ -33,11 +33,13 @@ class AdministrativeLevel(BaseModel):
     CANTON = 'canton'
     COMMUNE = 'commune'
     REGION = 'region'
+    PREFECTURE = 'prefecture'
     TYPE = (
         (VILLAGE, _('Village')),
         (CANTON, _('Canton')),
         (COMMUNE, _('Commune')),
         (REGION, _('Region')),
+        (PREFECTURE, _('Prefecture'))
     )
     parent = models.ForeignKey('AdministrativeLevel', null=True, blank=True, on_delete=models.CASCADE, verbose_name=_("Parent"))
     geographical_unit = models.ForeignKey('GeographicalUnit', null=True, blank=True, on_delete=models.CASCADE, verbose_name=_("Geographical unit"))
@@ -90,7 +92,22 @@ class AdministrativeLevel(BaseModel):
         for assign in self.assignadministrativeleveltofacilitator_set.get_queryset().filter(project_id__in=projects_ids, activated=True):
             return assign.facilitator
         return None
-    
+
+    def is_village(self):
+        return self.type.lower() == self.VILLAGE
+
+    def is_canton(self):
+        return self.type.lower() == self.CANTON
+
+    def is_commune(self):
+        return self.type.lower() == self.COMMUNE
+
+    def is_region(self):
+        return self.type.lower() == self.REGION
+
+    def is_prefecture(self):
+        return self.type.lower() == self.PREFECTURE
+
     @property
     def children(self):
         return self.administrativelevel_set.get_queryset()

--- a/cosomis/administrativelevels/templates/administrativelevel_create.html
+++ b/cosomis/administrativelevels/templates/administrativelevel_create.html
@@ -8,7 +8,7 @@
                 <div class="card-header">
                     <div class="col-md-12">
                         <div class="text-center">
-                            <a class="btn btn-primary" href="{% url 'administrativelevels:search_village' %}">{% translate 'Administrative levels' %}</a>
+                            <a class="btn btn-primary" href="{% url 'administrativelevels:search' %}">{% translate 'Administrative levels' %}</a>
                         </div>
                     {% comment %}
                         <div class="btn-group pull-right">

--- a/cosomis/administrativelevels/templates/administrativelevels_list.html
+++ b/cosomis/administrativelevels/templates/administrativelevels_list.html
@@ -57,8 +57,11 @@
                             {% for field in form %}
                             <div class="form-group row">
                                 <label class="col-3 col-form-label">{{ field.label }}</label>
-                                <div class="col-6" >
+                                <div class="col-6">
                                     {{ field }}
+                                </div>
+                                <div class="col-3">
+                                 <a id="check_{{ field.name }}" href="" class="btn btn-primary" style="display: none;">Check</a>
                                 </div>
                                 {% comment%}
                                 <div class="col-3" >
@@ -140,8 +143,12 @@
 
                 $('.adl-filter select').on("change", function () {
                     let elt_id = $(this).attr('id');
-                    if(elt_id && administrative_level_ids.includes(elt_id) && $(this).val() && $(this).val() != ''){
-
+                    if(elt_id && administrative_level_ids.includes(elt_id) && $(this).val() && $(this).val() != '') {
+                        const type = elt_id.split('_')[1].toLowerCase();
+                        const identifier = `check_`+ type ;
+                        document.getElementById(identifier).style.display = "block";
+                        let url = `{% url 'administrativelevels:list' %}` + type + '/' + $(this).val();
+                        document.getElementById(identifier).setAttribute('href', url);
 
                         $.ajax({
                             type: 'GET',
@@ -168,8 +175,6 @@
                                     set_datas($(`#id_canton`), data);
                                 }
                                 else if (elt_id == "id_canton") {
-                                    //console.log(data);
-                                    //set_datas($(`#search_results`), data);
                                     let container = $("#search_results")
                                     container.html('');
                                     let container_txt_html = "";
@@ -203,21 +208,14 @@
 
                                     $("#seeVillage").click(function(event){
                                         window.location.href = url_village;
-
                                     });
-
+                                    container[0].style.display = "block";
                                 }
                                 let i_start = 0
                                 if(next_index_adl_id !== null ){
                                     $(`#${administrative_level_ids[next_index_adl_id]}`).prop('disabled', false);
                                     i_start = next_index_adl_id+1;
                                 }
-                                for(let i=i_start; i < administrative_level_ids_length; i++){
-                                    $(`#${administrative_level_ids[i]}`).val(null).trigger('change.select2');
-                                    $(`#${administrative_level_ids[i]}`).prop('disabled', true);
-                                }
-
-
                             },
                             error: function (data) {
                                 alert(error_server_message + "Error " + data.status);
@@ -225,10 +223,25 @@
                             }
                         }).done(function () {
                             $(`#${elt_id}`).attr('disabled', false);
+                        });
+                    } else {
+                        const next_index = administrative_level_ids.indexOf(elt_id);
+
+                        for(let i=next_index; i < administrative_level_ids_length; i++) {
+                            const elt_id = administrative_level_ids[i]
+                            const type = elt_id.split('_')[1].toLowerCase();
+                            const identifier = `check_`+ type ;
+
+                            $(`#${elt_id}`).val(null).trigger('change.select2');
+                            document.getElementById(identifier).style.display = "none";
+                            if (i !== next_index) {
+                                $(`#${elt_id}`).prop('disabled', true);
+                            }
+                            if (i == administrative_level_ids_length - 1) {
+                                document.getElementById("villages_title").style.display = "none";
+                                document.getElementById("search_results").style.display = "none";
+                            }
                         }
-                        );
-                    }else{
-                        $(`#${elt_id}`).val(null).trigger('change.select2');
                     }
 
                 });
@@ -244,23 +257,23 @@
     $("#id_region").select2({
         placeholder: "{% translate 'Region' %}",
         allowClear: true,
-        width: '300px'
+        width: 'inherit'
     });
     $("#id_prefecture").select2({
         placeholder: "{% translate 'Prefecture' %}",
         allowClear: true,
-        width: '300px'
+        width: 'inherit'
 
     });
     $("#id_commune").select2({
         placeholder: "{% translate 'Commune' %}",
         allowClear: true,
-        width: '300px'
+        width: 'inherit'
     });
     $("#id_canton").select2({
         placeholder: "{% translate 'Canton' %}",
         allowClear: true,
-        width: '300px'
+        width: 'inherit'
     });
 
     $('b[role="presentation"]').hide();

--- a/cosomis/administrativelevels/templates/prefecture/prefecture_detail.html
+++ b/cosomis/administrativelevels/templates/prefecture/prefecture_detail.html
@@ -1,0 +1,12 @@
+{% extends 'layouts/base.html' %}
+{% load static i18n custom_tags %}
+
+{% block extracss %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'plugins/datepicker/date-picker.css' %}" />
+{% endblock %}
+
+
+{% block content %}
+Prefecture
+{% endblock %}

--- a/cosomis/administrativelevels/templates/region/region_detail.html
+++ b/cosomis/administrativelevels/templates/region/region_detail.html
@@ -1,0 +1,12 @@
+{% extends 'layouts/base.html' %}
+{% load static i18n custom_tags %}
+
+{% block extracss %}
+{{ block.super }}
+<link rel="stylesheet" href="{% static 'plugins/datepicker/date-picker.css' %}" />
+{% endblock %}
+
+
+{% block content %}
+Region
+{% endblock %}

--- a/cosomis/administrativelevels/urls.py
+++ b/cosomis/administrativelevels/urls.py
@@ -7,7 +7,7 @@ app_name = 'administrativelevels'
 
 urlpatterns = [
     path('', views.AdministrativeLevelsListView.as_view(), name='list'), # Administrative levels list path
-    path('search-village/', views.AdministrativeLevelSearchListView.as_view(), name='search_village'), # Administrative levels path to search a villages
+    path('search/', views.AdministrativeLevelSearchListView.as_view(), name='search'), # Administrative levels path to search
     path('create/', views.AdministrativeLevelCreateView.as_view(), name='create'), # Administrative level path to create
     path('update/<int:pk>/', views.AdministrativeLevelUpdateView.as_view(), name='update'), # Administrative level path to update
     path('village-detail/<int:pk>/', views.VillageDetailView.as_view(), name='village_detail'), #The path of the detail of village
@@ -23,6 +23,8 @@ urlpatterns = [
     path('canton/<int:pk>/', views.CantonDetailView.as_view(), name='canton_detail'),
     path('canton/<int:adm_id>/attachments/', views.CantonAttachmentListView.as_view(), name='canton_attachments'),
 
+    path('region/<int:pk>/', views.RegionDetailView.as_view(), name='region_detail'),
+    path('prefecture/<int:pk>/', views.PrefectureDetailView.as_view(), name='prefecture_detail'),
     # The path of the detail of village
     path('attachments/', views.AttachmentListView.as_view(), name='attachments'), # The path of the attachments list
 

--- a/cosomis/administrativelevels/views.py
+++ b/cosomis/administrativelevels/views.py
@@ -53,7 +53,7 @@ class VillageDetailView(PageMixin, LoginRequiredMixin, DetailView):
     
     def get_context_data(self, **kwargs):
         context = super(VillageDetailView, self).get_context_data(**kwargs)
-        if context.get("object") and context.get("object").type == "Village" : # Verify if the administrativeLevel type is Village
+        if context.get("object") and context.get("object").is_village() is True:
             return context
         raise Http404
 
@@ -838,11 +838,17 @@ class AttachmentListView(PageMixin, LoginRequiredMixin, TemplateView):
     model = Attachment
 
     def get_context_data(self, **kwargs):
+        context = super(AttachmentListView, self).get_context_data(**kwargs)
+        administrative_level = AdministrativeLevel.objects.filter(id=context.get("adm_id"))
+
+        if len(administrative_level) == 0:
+            raise Http404
+
+        context['administrative_level'] = administrative_level[0]
         self.activity_choices: List[Tuple] = [(None, '---')]
         self.task_choices: List[Tuple] = [(None, '---')]
         self.phase_choices: List[Tuple] = [(None, '---')]
         self.administrative_level_choices: List[Tuple] = [(None, '---')]
-        context = super(AttachmentListView, self).get_context_data(**kwargs)
 
         query_params: dict = self.request.GET
 
@@ -921,9 +927,8 @@ class VillageAttachmentListView(AttachmentListView):
 
     def get_context_data(self, **kwargs):
         context = super(VillageAttachmentListView, self).get_context_data(**kwargs)
-        village_exist = AdministrativeLevel.objects.filter(id=context.get("adm_id"), type="Village")
 
-        if len(village_exist) == 0:
+        if context['administrative_level'].is_village() is False:
             raise Http404
 
         return context
@@ -1383,16 +1388,15 @@ class CommuneDetailView(PageMixin, LoginRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super(CommuneDetailView, self).get_context_data(**kwargs)
         if context.get("object") and context.get(
-                "object").type == "Commune":
+                "object").is_commune() is True:
             return context
         raise Http404
 
 class CommuneAttachmentListView(AttachmentListView):
     def get_context_data(self, **kwargs):
         context = super(CommuneAttachmentListView, self).get_context_data(**kwargs)
-        commune_exist = AdministrativeLevel.objects.filter(id=context.get("adm_id"), type="Commune")
 
-        if len(commune_exist) == 0:
+        if  context['administrative_level'].is_commune() is False:
             raise Http404
 
         return context
@@ -1414,16 +1418,58 @@ class CantonDetailView(PageMixin, LoginRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super(CantonDetailView, self).get_context_data(**kwargs)
         if context.get("object") and context.get(
-                "object").type == "Canton":
+                "object").is_canton() is True:
             return context
         raise Http404
 
 class CantonAttachmentListView(AttachmentListView):
     def get_context_data(self, **kwargs):
         context = super(CantonAttachmentListView, self).get_context_data(**kwargs)
-        canton_exist = AdministrativeLevel.objects.filter(id=context.get("adm_id"), type="Canton")
 
-        if len(canton_exist) == 0:
+        if context['administrative_level'].is_canton() is False:
             raise Http404
 
         return context
+
+# Region
+class RegionDetailView(PageMixin, LoginRequiredMixin, DetailView):
+    model = AdministrativeLevel
+    template_name = 'region/region_detail.html'
+    context_object_name = 'region'
+    title = _('Region')
+    active_level1 = 'administrative_levels'
+    breadcrumb = [
+        {
+            'url': '',
+            'title': title
+        },
+    ]
+
+    def get_context_data(self, **kwargs):
+        context = super(RegionDetailView, self).get_context_data(**kwargs)
+        if context.get("object") and context.get(
+                "object").is_region() is True:
+            return context
+        raise Http404
+
+
+# Prefecture
+class PrefectureDetailView(PageMixin, LoginRequiredMixin, DetailView):
+    model = AdministrativeLevel
+    template_name = 'prefecture/prefecture_detail.html'
+    context_object_name = 'prefecture'
+    title = _('Prefecture')
+    active_level1 = 'administrative_levels'
+    breadcrumb = [
+        {
+            'url': '',
+            'title': title
+        },
+    ]
+
+    def get_context_data(self, **kwargs):
+        context = super(PrefectureDetailView, self).get_context_data(**kwargs)
+        if context.get("object") and context.get(
+                "object").is_prefecture() is True:
+            return context
+        raise Http404

--- a/cosomis/cosomis/templates/layouts/navbar.html
+++ b/cosomis/cosomis/templates/layouts/navbar.html
@@ -26,7 +26,7 @@
             </li>
         {% elif administrativelevel_profile %}
             <li class="nav-item white-shaded-nav-item">
-                <a class="nav-link font-weight-bold" href="{% url 'administrativelevels:search_village' %}"
+                <a class="nav-link font-weight-bold" href="{% url 'administrativelevels:search' %}"
                 role="button"><i class="fas fa-chevron-left text-primary"></i></a>
             </li>
             <li class="nav-item shadow-sm bg-light rounded pt-2" style="margin-left: 25px; padding-left: 15px; padding-right: 15px;">

--- a/cosomis/cosomis/templates/layouts/sidebar.html
+++ b/cosomis/cosomis/templates/layouts/sidebar.html
@@ -69,9 +69,9 @@
                 </li>
                 <li class="nav-item">
                     <a 
-                        href="{% url 'administrativelevels:search_village' %}"
+                        href="{% url 'administrativelevels:search' %}"
                         {% comment %}href="{% url 'administrativelevels:list' %}"{% endcomment %}
-                       class="nav-link {% if url_name == 'search_village' %}active{% endif %}">
+                       class="nav-link {% if url_name == 'search' %}active{% endif %}">
                         <i class="nav-icon fa fa-home"></i>
                         <p>{% translate "Administrative levels" %}</p>
                     </a>


### PR DESCRIPTION
Update search page for all administrative levels. Also, fixed that when you de-select an option the content is erased and when you select, you have the option to go to detail

## How to test?

- [ ] Select options in selectors and see that the Check button appears
- [ ] Check you can navigate to the detail page of the admin level
- [ ] When you erase an option all the children selector disappear and also their Check button
- [ ] When you erase an option check that village list dissapear too.