### PR TITLE
improve switching between dev db & prod db

### DIFF
--- a/cosomis/cosomis/settings.py
+++ b/cosomis/cosomis/settings.py
@@ -114,12 +114,9 @@ WSGI_APPLICATION = 'cosomis.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
-EXTERNAL_DATABASE_NAME = 'cddp'
-
 FALLBACK_SQLITE_DB_FILE = os.path.join(BASE_DIR, 'database1.db')
 DATABASES = {
     'default': env.db_url('DATABASE_URL', default=f'sqlite:///{FALLBACK_SQLITE_DB_FILE}'),
-    EXTERNAL_DATABASE_NAME: env.db('LEGACY_DATABASE_URL')
 }
 
 MAX_RESPONSE_DAYS = 3

--- a/cosomis/cosomis/settings.py
+++ b/cosomis/cosomis/settings.py
@@ -116,19 +116,11 @@ WSGI_APPLICATION = 'cosomis.wsgi.application'
 
 EXTERNAL_DATABASE_NAME = 'cddp'
 
-# DATABASES = {
-#     'default': env.db(),
-#     EXTERNAL_DATABASE_NAME: env.db('LEGACY_DATABASE_URL')
-# }
-
+FALLBACK_SQLITE_DB_FILE = os.path.join(BASE_DIR, 'database1.db')
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        #'NAME': '/Users/asucr/Downloads/database1.db',  # This is where you put the name of the db file.
-        # If one doesn't exist, it will be created at migration time.
-        'NAME': os.path.join(BASE_DIR, 'database1.db'),
-    }
- }
+    'default': env.db_url('DATABASE_URL', default=f'sqlite:///{FALLBACK_SQLITE_DB_FILE}'),
+    EXTERNAL_DATABASE_NAME: env.db('LEGACY_DATABASE_URL')
+}
 
 MAX_RESPONSE_DAYS = 3
 


### PR DESCRIPTION
This changes make it easier to use the prod db when deploying while also making it easy to develop with SQLITE.
If you are developing and want to use sqlite db, just remove or comment the line `DATABASE_URL` in your `.env` file. it will fallback to a SQLITE database.