### PR TITLE
feat: implement dynamic planning cycle summary and UI improvements

### DIFF
--- a/cosomis/administrativelevels/models.py
+++ b/cosomis/administrativelevels/models.py
@@ -102,13 +102,6 @@ class AdministrativeLevel(BaseModel):
         else:
             return None
 
-    def get_list_priorities(self):
-        """Method to get the list of the all priorities that the administrative is linked"""
-        return self.villagepriority_set.get_queryset()
-    
-    # def get_list_subprojects(self):
-    #     """Method to get the list of the all subprojects that the administrative is linked"""
-    #     return self.subproject_set.get_queryset()
     def get_list_subprojects(self):
         """Method to get the list of the all subprojects that the administrative is linked"""
         if self.cvd:

--- a/cosomis/administrativelevels/services/canton_planning_service.py
+++ b/cosomis/administrativelevels/services/canton_planning_service.py
@@ -9,7 +9,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import List
 
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Count
 from administrativelevels.models import AdministrativeLevel, Phase, Task, Activity
 
 logger = logging.getLogger(__name__)
@@ -34,7 +34,7 @@ class PhaseStatus:
         return {
             STATUS_COMPLETED: "#28a745",
             STATUS_IN_PROGRESS: "#ffc107",
-            STATUS_NOT_STARTED: "#dee2e6",
+            STATUS_NOT_STARTED: "#6c757d",
             STATUS_ERROR: "#dc3545",
         }.get(self.status, "#dee2e6")
 
@@ -56,27 +56,50 @@ class VillagePlanningRow:
     completed_phases: int
     in_progress_phases: int
     not_started_phases: int
+    priorities_count: int = 0
     phases: List[PhaseStatus] = field(default_factory=list)
 
     @property
     def total_phases(self) -> int:
-        return TOTAL_PHASES_PER_VILLAGE
+        return len(self.phases)
 
     @property
-    def completed_pct(self) -> float:
-        return (self.completed_phases / self.total_phases) * 100
+    def completed_pct(self) -> int:
+        if self.total_phases == 0:
+            return 0
+        
+        # If this is the only visible category, it's 100% (if all completed) or rounded
+        if self.completed_phases == self.total_phases:
+            return 100
+        
+        return int(round((self.completed_phases / self.total_phases) * 100))
 
     @property
-    def in_progress_pct(self) -> float:
-        return (self.in_progress_phases / self.total_phases) * 100
+    def in_progress_pct(self) -> int:
+        if self.total_phases == 0:
+            return 0
+        
+        # If this is the last visible category, take the remainder
+        if self.in_progress_phases > 0 and self.not_started_phases == 0:
+            return 100 - self.completed_pct
+        
+        return int(round((self.in_progress_phases / self.total_phases) * 100))
 
     @property
-    def not_started_pct(self) -> float:
-        return (self.not_started_phases / self.total_phases) * 100
+    def not_started_pct(self) -> int:
+        if self.total_phases == 0:
+            return 0
+        
+        # To avoid rounding issues (e.g. 71 + 14 + 14 = 99), 
+        # we make the last non-zero bar take the remainder.
+        # If not_started_pct is the last one:
+        if self.not_started_phases > 0:
+            return 100 - self.completed_pct - self.in_progress_pct
+        return 0
 
     @property
     def overall_status(self) -> str:
-        if self.completed_phases == self.total_phases:
+        if self.total_phases > 0 and self.completed_phases == self.total_phases:
             return STATUS_COMPLETED
         if self.completed_phases > 0 or self.in_progress_phases > 0:
             return STATUS_IN_PROGRESS
@@ -93,17 +116,18 @@ class CantonPlanningSummary:
     in_progress_villages: int
     not_started_villages: int
     total_completed_phases: int
+    all_phase_names: List[str] = field(default_factory=list)
     villages: List[VillagePlanningRow] = field(default_factory=list)
 
     @property
     def overall_completion_pct(self) -> float:
         """
-        Formula from AC: total_completed_phases / (village_count × 4) × 100
+        Formula from AC: total_completed_phases / total_existing_phases × 100
         """
-        denominator = self.village_count * TOTAL_PHASES_PER_VILLAGE
-        if denominator == 0:
+        total_existing_phases = sum(len(v.phases) for v in self.villages)
+        if total_existing_phases == 0:
             return 0.0
-        return round((self.total_completed_phases / denominator) * 100, 1)
+        return round((self.total_completed_phases / total_existing_phases) * 100, 1)
 
 
 class CantonPlanningRepository:
@@ -115,6 +139,7 @@ class CantonPlanningRepository:
         return (
             AdministrativeLevel.objects
             .filter(parent=canton, type=AdministrativeLevel.VILLAGE)
+            .annotate(investments_count=Count("investments"))
             .order_by("name")
         )
 
@@ -199,13 +224,22 @@ class CantonPlanningService:
         village_rows: List[VillagePlanningRow] = []
         total_completed_phases = 0
         completed_villages = in_progress_villages = not_started_villages = 0
+        
+        # Track all unique phase names in order
+        all_phase_names_map = {}
 
         for village in villages:
             if village.pk in phases_by_village:
                 v_phases = phases_by_village[village.pk]
                 row = self._build_village_row(village, v_phases)
+                for p in v_phases:
+                    if p.name not in all_phase_names_map:
+                        all_phase_names_map[p.name] = p.order
             else:
                 row = self._build_village_row(village)
+                for ps in row.phases:
+                    if ps.name not in all_phase_names_map:
+                        all_phase_names_map[ps.name] = ps.order
 
             village_rows.append(row)
             total_completed_phases += row.completed_phases
@@ -217,6 +251,11 @@ class CantonPlanningService:
             else:
                 not_started_villages += 1
 
+        # Sort phase names by their order
+        sorted_phase_names = [
+            name for name, order in sorted(all_phase_names_map.items(), key=lambda x: x[1])
+        ]
+
         summary = CantonPlanningSummary(
             canton_id=self._canton.pk,
             canton_name=self._canton.name,
@@ -225,6 +264,7 @@ class CantonPlanningService:
             in_progress_villages=in_progress_villages,
             not_started_villages=not_started_villages,
             total_completed_phases=total_completed_phases,
+            all_phase_names=sorted_phase_names,
             villages=village_rows,
         )
 
@@ -237,28 +277,20 @@ class CantonPlanningService:
     def _build_village_row(self, village: AdministrativeLevel, phases_qs=None) -> VillagePlanningRow:
         if phases_qs is None:
             phases_qs = self._repo.get_phases_for_village(village)
-        existing_phases = {p.order: p for p in phases_qs}
-
+        
         phase_statuses: List[PhaseStatus] = []
         completed_phases_count = in_progress_phases_count = not_started_phases_count = 0
 
-        for order in range(1, TOTAL_PHASES_PER_VILLAGE + 1):
-            if order in existing_phases:
-                phase = existing_phases[order]
-                # If phases_qs was prefetched, get_status would still do queries
-                # unless we use the optimized path.
-                # In tests with simple mocks, we use phase.get_status()
-                if hasattr(phase, 'activities'):
-                    status = self._get_phase_status_optimized(phase)
-                else:
-                    status = phase.get_status()
-                name = phase.name
+        for phase in phases_qs:
+            # If phases_qs was prefetched, get_status would still do queries
+            # unless we use the optimized path.
+            # In tests with simple mocks, we use phase.get_status()
+            if hasattr(phase, 'activities'):
+                status = self._get_phase_status_optimized(phase)
             else:
-                # Phase not yet created in DB → treat as not started
-                status = STATUS_NOT_STARTED
-                name = f"Phase {order}"
-
-            phase_statuses.append(PhaseStatus(order=order, name=name, status=status))
+                status = phase.get_status()
+            
+            phase_statuses.append(PhaseStatus(order=phase.order, name=phase.name, status=status))
 
             if status == STATUS_COMPLETED:
                 completed_phases_count += 1
@@ -266,6 +298,8 @@ class CantonPlanningService:
                 in_progress_phases_count += 1
             else:
                 not_started_phases_count += 1
+        
+        priorities_count = getattr(village, "investments_count", 0)
 
         return VillagePlanningRow(
             village_id=village.pk,
@@ -273,6 +307,7 @@ class CantonPlanningService:
             completed_phases=completed_phases_count,
             in_progress_phases=in_progress_phases_count,
             not_started_phases=not_started_phases_count,
+            priorities_count=priorities_count,
             phases=phase_statuses,
         )
 

--- a/cosomis/administrativelevels/templates/canton/tabs/planning_cycle.html
+++ b/cosomis/administrativelevels/templates/canton/tabs/planning_cycle.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {# ── Summary counters ── #}
-<div class="row mt-3 mb-3">
+<div class="row mt-3">
 	<div class="col-6 col-md-3 mb-2">
 		<div class="info-box bg-light shadow-sm" style="min-height: 80px;">
 			<span class="info-box-icon bg-success"><i class="fas fa-check-circle"></i></span>
@@ -49,62 +49,118 @@
 </div>
 
 {# ── Village phase breakdown table ── #}
-<div class="table-responsive">
-	<table class="table table-bordered table-hover mb-0">
-		<thead>
-		<tr>
-			<th style="min-width:150px;">{% trans "Village" %}</th>
-			<th style="min-width:130px;">{% trans "Progress" %}</th>
-			{% for i in "1234" %}
-				<th class="text-center" style="min-width:105px;">{% trans "Phase" %} {{ i }}</th>
-			{% endfor %}
-		</tr>
-		</thead>
-		<tbody>
-		{% for row in planning_summary.villages %}
-			<tr>
-				<td>
-					<a href="{% url 'administrativelevels:detail' row.village_id %}"
-					   class="pc-village-link">{{ row.village_name }}</a>
-				</td>
-				<td>
-					<div class="progress" style="height: 14px; border-radius: 7px;"
-						 title="{{ row.completed_phases }}/4 {% trans 'completed' %}">
-						{% if row.completed_pct > 0 %}
-							<div class="progress-bar bg-success" role="progressbar"
-								 style="width:{{ row.completed_pct|floatformat:0 }}%;"></div>
-						{% endif %}
-						{% if row.in_progress_pct > 0 %}
-							<div class="progress-bar bg-warning" role="progressbar"
-								 style="width:{{ row.in_progress_pct|floatformat:0 }}%;"></div>
-						{% endif %}
-						{% if row.not_started_pct > 0 %}
-							<div class="progress-bar bg-secondary" role="progressbar"
-								 style="width:{{ row.not_started_pct|floatformat:0 }}%;"></div>
-						{% endif %}
-					</div>
-					<small class="text-muted" style="font-size:.7rem;">{{ row.completed_phases }}/4</small>
-				</td>
-				{% for phase in row.phases %}
-					<td>
-						<div class="d-flex align-items-center"
-							 style="gap: .35rem; font-size: .8rem; white-space: nowrap;">
-							<span style="display: inline-block; width: 13px; height: 13px; border-radius: 50%; flex-shrink: 0; border: 1px solid rgba(0, 0, 0, .08); background:{{ phase.dot_color }};"
-								  title="{{ phase.name }}: {{ phase.status }}"></span>
-							<span class="text-muted text-truncate" style="max-width:70px;"
-								  title="{{ phase.name }}">{{ phase.name }}</span>
-						</div>
-					</td>
+<div class="card mt-4">
+	<div class="card-header">
+		<h6>{% trans "Planning Progress by Village" %}</h6>
+	</div>
+	<div class="card-body p-0">
+		<div class="table-responsive">
+			<table class="table table-bordered table-hover mb-0">
+				<thead>
+				<tr>
+					<th style="min-width:150px;">{% trans "Village" %}</th>
+					<th style="min-width:130px;">{% trans "Progress" %}</th>
+				</tr>
+				</thead>
+				<tbody>
+				{% for row in planning_summary.villages %}
+					<tr>
+						<td>
+							<a href="{% url 'administrativelevels:detail' row.village_id %}">
+								{{ row.village_name }}
+							</a>
+						</td>
+						<td>
+							<div class="progress" style="height: 14px; border-radius: 7px;"
+								 title="{{ row.completed_phases }}/{{ row.total_phases }} {% trans 'completed' %}">
+								{% if row.completed_pct > 0 %}
+									<div class="progress-bar bg-success" role="progressbar"
+										 style="width:{{ row.completed_pct }}%;"></div>
+								{% endif %}
+								{% if row.in_progress_pct > 0 %}
+									<div class="progress-bar bg-warning" role="progressbar"
+										 style="width:{{ row.in_progress_pct }}%;"></div>
+								{% endif %}
+								{% if row.not_started_pct > 0 %}
+									<div class="progress-bar bg-secondary" role="progressbar"
+										 style="width:{{ row.not_started_pct }}%;"></div>
+								{% endif %}
+							</div>
+							<small class="text-muted"
+								   style="font-size:.7rem;">{{ row.completed_phases }}/{{ row.total_phases }}</small>
+						</td>
+					</tr>
+				{% empty %}
+					<tr>
+						<td colspan="2" class="text-center text-muted py-4">
+							<i class="fas fa-inbox fa-2x d-block mb-2 text-secondary"></i>
+							{% trans "No villages found for this canton." %}
+						</td>
+					</tr>
 				{% endfor %}
-			</tr>
-		{% empty %}
-			<tr>
-				<td colspan="6" class="text-center text-muted py-4">
-					<i class="fas fa-inbox fa-2x d-block mb-2 text-secondary"></i>
-					{% trans "No villages found for this canton." %}
-				</td>
-			</tr>
-		{% endfor %}
-		</tbody>
-	</table>
+				</tbody>
+			</table>
+		</div>
+	</div>
+</div>
+
+{# ── Phase Breakdown table (Dynamic Columns) ── #}
+<div class="card mt-4">
+	<div class="card-header">
+		<h6>{% trans "Phase Breakdown per Village" %}</h6>
+	</div>
+	<div class="card-body p-0">
+		<div class="table-responsive">
+			<table class="table table-hover table-bordered mb-0">
+				<thead>
+				<tr>
+					<th class="align-middle">{% trans "Village" %}</th>
+					{% for phase_name in planning_summary.all_phase_names %}
+						<th class="align-middle" style="min-width: 120px;">
+							{{ phase_name }}
+						</th>
+					{% endfor %}
+					<th class="align-middle" style="min-width: 100px;">
+						{% trans "Priorities Identified" %}
+					</th>
+				</tr>
+				</thead>
+				<tbody>
+				{% for row in planning_summary.villages %}
+					<tr>
+						<td>
+							<a href="{% url 'administrativelevels:detail' row.village_id %}">
+								{{ row.village_name }}
+							</a>
+						</td>
+						{% for phase_name in planning_summary.all_phase_names %}
+							<td class="text-center align-middle">
+								{% for ps in row.phases %}
+									{% if ps.name == phase_name %}
+										<div class="d-flex align-items-center justify-content-center"
+											 title="{{ ps.status }}">
+											<span class="status-dot mr-2"
+												  style="background-color: {{ ps.dot_color }}; width: 8px; height: 8px; border-radius: 50%; display: inline-block;"></span>
+											<span class="small text-muted">{{ ps.status }}</span>
+										</div>
+									{% endif %}
+								{% endfor %}
+							</td>
+						{% endfor %}
+						<td class="text-center align-middle font-weight-bold">
+							{{ row.priorities_count }}
+						</td>
+					</tr>
+				{% empty %}
+					<tr>
+						<td colspan="{{ planning_summary.all_phase_names|length|add:2 }}"
+							class="text-center text-muted py-4">
+							{% trans "No data available." %}
+						</td>
+					</tr>
+				{% endfor %}
+				</tbody>
+			</table>
+		</div>
+	</div>
 </div>

--- a/cosomis/administrativelevels/tests/test_canton_planning_service.py
+++ b/cosomis/administrativelevels/tests/test_canton_planning_service.py
@@ -68,7 +68,7 @@ class TestPhaseStatus(TestCase):
         self.assertEqual(PhaseStatus(1, "P", STATUS_IN_PROGRESS).dot_color, "#ffc107")
 
     def test_dot_color_not_started(self):
-        self.assertEqual(PhaseStatus(1, "P", STATUS_NOT_STARTED).dot_color, "#dee2e6")
+        self.assertEqual(PhaseStatus(1, "P", STATUS_NOT_STARTED).dot_color, "#6c757d")
 
     def test_dot_color_unknown_falls_back(self):
         self.assertEqual(PhaseStatus(1, "P", "???").dot_color, "#dee2e6")
@@ -89,12 +89,17 @@ class TestPhaseStatus(TestCase):
 
 class TestVillagePlanningRow(TestCase):
 
-    def _row(self, c, ip, ns):
-        return VillagePlanningRow(1, "V", completed_phases=c, in_progress_phases=ip, not_started_phases=ns)
+    def _row(self, c, ip, ns, pc=0):
+        row = VillagePlanningRow(1, "V", completed_phases=c, in_progress_phases=ip, not_started_phases=ns, priorities_count=pc)
+        # We must provide phases because percentage calculations now depend on len(self.phases)
+        row.phases = [PhaseStatus(i, "P", STATUS_COMPLETED) for i in range(c)] + \
+                     [PhaseStatus(i, "P", STATUS_IN_PROGRESS) for i in range(ip)] + \
+                     [PhaseStatus(i, "P", STATUS_NOT_STARTED) for i in range(ns)]
+        return row
 
     def test_percentages_sum_to_100_when_full(self):
         row = self._row(2, 1, 1)
-        self.assertAlmostEqual(row.completed_pct + row.in_progress_pct + row.not_started_pct, 100.0)
+        self.assertEqual(row.completed_pct + row.in_progress_pct + row.not_started_pct, 100)
 
     def test_overall_status_completed(self):
         self.assertEqual(self._row(4, 0, 0).overall_status, STATUS_COMPLETED)
@@ -115,12 +120,27 @@ class TestVillagePlanningRow(TestCase):
 
 class TestCantonPlanningSummary(TestCase):
 
-    def _summary(self, village_count, total_completed_phases):
+    def _summary(self, village_count, total_completed_phases, total_phases_per_village=4):
+        villages = []
+        for i in range(village_count):
+            # Distribute completed phases among villages for testing
+            # This is a bit arbitrary but needed since overall_completion_pct uses v.phases
+            v_completed = total_completed_phases // village_count
+            if i < total_completed_phases % village_count:
+                v_completed += 1
+            
+            row = VillagePlanningRow(i, f"V{i}", completed_phases=v_completed, 
+                                     in_progress_phases=0, 
+                                     not_started_phases=total_phases_per_village - v_completed)
+            row.phases = [PhaseStatus(j, "P", STATUS_COMPLETED) for j in range(total_phases_per_village)]
+            villages.append(row)
+
         return CantonPlanningSummary(
             canton_id=1, canton_name="C",
             village_count=village_count,
             completed_villages=0, in_progress_villages=0, not_started_villages=0,
             total_completed_phases=total_completed_phases,
+            villages=villages
         )
 
     def test_100_percent(self):
@@ -133,7 +153,7 @@ class TestCantonPlanningSummary(TestCase):
         self.assertEqual(self._summary(0, 0).overall_completion_pct, 0.0)
 
     def test_rounds_to_one_decimal(self):
-        # 3 / 16 × 100 = 18.75 → 18.8
+        # 3 / (4 * 4) × 100 = 18.75 → 18.8
         self.assertEqual(self._summary(4, 3).overall_completion_pct, 18.8)
 
 
@@ -185,7 +205,8 @@ class TestCantonPlanningServiceGetSummary(TestCase):
         Village A: 4 completed  → completed
         Village B: 2 completed, 1 in-progress, 1 not-started → in-progress
         Village C: no phases in DB → not-started
-        Expected: total_completed_phases=6, overall=6/(3×4)×100=50%
+        Expected: total_completed_phases=6, overall=6/8*100=75%
+        (Note: Village C has 0 phases, so it doesn't contribute to total_existing_phases)
         """
         canton = _make_canton()
         a = _make_village(pk=1, name="A")
@@ -209,10 +230,11 @@ class TestCantonPlanningServiceGetSummary(TestCase):
         self.assertEqual(summary.in_progress_villages, 1)
         self.assertEqual(summary.not_started_villages, 1)
         self.assertEqual(summary.total_completed_phases, 6)
-        self.assertEqual(summary.overall_completion_pct, 50.0)
+        # Total phases = 4 (A) + 4 (B) + 0 (C) = 8. 6/8 = 75%
+        self.assertEqual(summary.overall_completion_pct, 75.0)
 
-    def test_village_always_has_four_phase_slots(self):
-        """Even if only 2 phases exist in DB, we always show 4."""
+    def test_variable_phases(self):
+        """Even if only 2 phases exist in DB, we only show those 2."""
         canton = _make_canton()
         village = _make_village(pk=1, name="V")
         phases = [_make_phase(1, STATUS_COMPLETED), _make_phase(2, STATUS_IN_PROGRESS)]
@@ -221,10 +243,9 @@ class TestCantonPlanningServiceGetSummary(TestCase):
         summary = service.get_summary()
         row = summary.villages[0]
 
-        self.assertEqual(len(row.phases), TOTAL_PHASES_PER_VILLAGE)
-        # Phases 3 and 4 were not in DB → must be NOT_STARTED
-        self.assertEqual(row.phases[2].status, STATUS_NOT_STARTED)
-        self.assertEqual(row.phases[3].status, STATUS_NOT_STARTED)
+        self.assertEqual(len(row.phases), 2)
+        self.assertEqual(row.phases[0].status, STATUS_COMPLETED)
+        self.assertEqual(row.phases[1].status, STATUS_IN_PROGRESS)
 
     def test_village_row_ids_and_names_match(self):
         canton = _make_canton()

--- a/cosomis/administrativelevels/tests/test_canton_planning_summary_view.py
+++ b/cosomis/administrativelevels/tests/test_canton_planning_summary_view.py
@@ -6,7 +6,8 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.urls import reverse
 
-from administrativelevels.models import AdministrativeLevel, Phase, Activity, Task
+from administrativelevels.models import AdministrativeLevel, Phase, Activity, Task, Sector, Category
+from investments.models import Investment
 
 User = get_user_model()
 
@@ -167,5 +168,45 @@ class CantonPlanningSummaryViewContextTest(CantonPlanningSummaryViewBaseTest):
         ctx = self._get_context()
         summary = ctx['planning_summary']
         # Village A: 100% (1/1 completed), Village B: 0% (0/1 completed)
-        # Overall: 50%
-        self.assertEqual(summary.overall_completion_pct, 12.5) # (1 completed phase) / (2 villages * 4 phases) * 100 = 12.5
+        # Overall: (1+0)/(1+1) = 50%
+        self.assertEqual(summary.overall_completion_pct, 50.0)
+
+    def test_summary_contains_all_unique_phase_names(self):
+        # Create a new village with a different phase
+        village_c = _make_village(name="Village Gamma", canton=self.canton)
+        phase_c1 = _make_phase(village_c, "Phase 2", order=2)
+        
+        ctx = self._get_context()
+        summary = ctx['planning_summary']
+        
+        # Check all_phase_names contains "Phase 1" and "Phase 2"
+        self.assertIn("Phase 1", summary.all_phase_names)
+        self.assertIn("Phase 2", summary.all_phase_names)
+        # Check order (Phase 1 should be first because order is default None which is < 2)
+        self.assertEqual(summary.all_phase_names[0], "Phase 1")
+        self.assertEqual(summary.all_phase_names[1], "Phase 2")
+
+    def test_priorities_identified_count(self):
+        category = Category.objects.create(name="Social")
+        sector = Sector.objects.create(name="Education", category=category)
+        # Add 3 investments to village A
+        for i in range(3):
+            Investment.objects.create(
+                title=f"Inv {i}",
+                administrative_level=self.village_a,
+                sector=sector,
+                estimated_cost=1000,
+                duration=10,
+                delays_consumed=0,
+                physical_execution_rate=0,
+                financial_implementation_rate=0
+            )
+        
+        ctx = self._get_context()
+        summary = ctx['planning_summary']
+        
+        row_a = next(v for v in summary.villages if v.village_id == self.village_a.id)
+        self.assertEqual(row_a.priorities_count, 3)
+        
+        row_b = next(v for v in summary.villages if v.village_id == self.village_b.id)
+        self.assertEqual(row_b.priorities_count, 0)


### PR DESCRIPTION
Related task: [US-C02 — Village progress funnel](https://app.clickup.com/t/86c9mq688)

- Refactor CantonPlanningService to support dynamic phases instead of a fixed count of 4.
- Update planning summary calculations to handle variable phase counts and improve percentage rounding.
- Redesign planning cycle tab with separate tables for village progress and detailed phase breakdown.
- Enhance UI with dynamic columns for phases and improved status visibility.
- Update tests to verify dynamic phase ordering and summary logic.