### PR TITLE
fix(administrativelevels): centralize type aliases so non-Togo datasets don't 500

### DIFF
--- a/cosomis/administrativelevels/models.py
+++ b/cosomis/administrativelevels/models.py
@@ -1,5 +1,6 @@
 import json
 from django.db import models
+from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from usermanager.models import User, Organization
 from cosomis.models_base import BaseModel
@@ -46,6 +47,19 @@ class AdministrativeLevel(BaseModel):
         (REGION, _('Region'))
     )
 
+    # Different country datasets store the same logical level under different
+    # type strings — e.g. the Benin dataset uses 'arrondissement' for Canton
+    # and 'département' for Prefecture. All comparisons against `type` go
+    # through aliases_for() / type_filter_q() / is_*() so call sites never
+    # hard-code a single spelling.
+    TYPE_ALIASES = {
+        VILLAGE: ('village',),
+        CANTON: ('canton', 'arrondissement'),
+        COMMUNE: ('commune',),
+        PREFECTURE: ('prefecture', 'département', 'departement'),
+        REGION: ('region', 'région'),
+    }
+
     # system properties
     parent = models.ForeignKey('AdministrativeLevel', null=True, blank=True, on_delete=models.CASCADE, verbose_name=_("Parent"), related_name='children')
     type = models.CharField(max_length=255, verbose_name=_("Type"), choices=TYPE, default=VILLAGE)
@@ -90,7 +104,7 @@ class AdministrativeLevel(BaseModel):
         return self.name
 
     def get_current_task(self):
-        if self.type == self.VILLAGE:
+        if self.is_village():
             phases = Phase.objects.filter(village=self).order_by('-order')
             for phase in phases:
                 activities = phase.activities.all().order_by('-order')
@@ -113,20 +127,39 @@ class AdministrativeLevel(BaseModel):
             return assign.facilitator
         return None
 
+    @classmethod
+    def aliases_for(cls, canonical_type):
+        """All lowercase type strings that resolve to the given canonical type."""
+        return cls.TYPE_ALIASES.get(canonical_type, (canonical_type.lower(),))
+
+    @classmethod
+    def matches_type(cls, stored_type, canonical_type):
+        if not stored_type:
+            return False
+        return stored_type.strip().lower() in cls.aliases_for(canonical_type)
+
+    @classmethod
+    def type_filter_q(cls, canonical_type, field="type"):
+        """Q expression matching any stored alias of `canonical_type` (case-insensitive)."""
+        q = Q()
+        for alias in cls.aliases_for(canonical_type):
+            q |= Q(**{f"{field}__iexact": alias})
+        return q
+
     def is_village(self):
-        return self.type.lower() == self.VILLAGE.lower()
+        return self.matches_type(self.type, self.VILLAGE)
 
     def is_canton(self):
-        return self.type.lower() == self.CANTON.lower()
+        return self.matches_type(self.type, self.CANTON)
 
     def is_commune(self):
-        return self.type.lower() == self.COMMUNE.lower()
+        return self.matches_type(self.type, self.COMMUNE)
 
     def is_region(self):
-        return self.type.lower() == self.REGION.lower()
+        return self.matches_type(self.type, self.REGION)
 
     def is_prefecture(self):
-        return self.type.lower() == self.PREFECTURE.lower()
+        return self.matches_type(self.type, self.PREFECTURE)
 
     @property
     def children(self):
@@ -145,7 +178,7 @@ class AdministrativeLevel(BaseModel):
 
     def get_villages_coordinates(self):
         coordinates = list()
-        if self.type == self.VILLAGE:
+        if self.is_village():
             if self.longitude is not None and self.latitude is not None:
                 return {
                     "name": self.name,
@@ -153,7 +186,7 @@ class AdministrativeLevel(BaseModel):
                     "coordinates": [float(self.longitude), float(self.latitude)]
                 }
         for child in self.children.all():
-            if child.type == self.VILLAGE:
+            if child.is_village():
                 if child.longitude is not None and child.latitude is not None:
                     coordinates.append(child.get_villages_coordinates())
             else:

--- a/cosomis/administrativelevels/services/canton_map_service.py
+++ b/cosomis/administrativelevels/services/canton_map_service.py
@@ -81,8 +81,9 @@ class CantonMapService:
     """
 
     def __init__(self, canton: AdministrativeLevel) -> None:
-        assert canton.type == AdministrativeLevel.CANTON, (
-            "CantonMapService must receive a Canton-type AdministrativeLevel"
+        assert canton.is_canton(), (
+            f"CantonMapService must receive a Canton-type AdministrativeLevel "
+            f"(got type={canton.type!r})"
         )
         self._canton = canton
         self._color_registry = _CategoryColorRegistry()
@@ -135,7 +136,8 @@ class CantonMapService:
         return list(
             AdministrativeLevel.objects.filter(
                 parent=self._canton,
-                type=AdministrativeLevel.VILLAGE,
+            ).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE),
             )
             .prefetch_related(
                 # investments for priorities and subprojects layers

--- a/cosomis/administrativelevels/services/canton_planning_service.py
+++ b/cosomis/administrativelevels/services/canton_planning_service.py
@@ -138,7 +138,8 @@ class CantonPlanningRepository:
     def get_villages_for_canton(self, canton: AdministrativeLevel):
         return (
             AdministrativeLevel.objects
-            .filter(parent=canton, type=AdministrativeLevel.VILLAGE)
+            .filter(parent=canton)
+            .filter(AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE))
             .annotate(investments_count=Count("investments"))
             .order_by("name")
         )
@@ -195,8 +196,8 @@ class CantonPlanningService:
     """
 
     def __init__(self, canton: AdministrativeLevel, repository: CantonPlanningRepository = None):
-        assert canton.type == AdministrativeLevel.CANTON, (
-            f"Expected CANTON, got {canton.type}"
+        assert canton.is_canton(), (
+            f"Expected canton-type AdministrativeLevel, got type={canton.type!r}"
         )
         self._canton = canton
         self._repo = repository or CantonPlanningRepository()

--- a/cosomis/administrativelevels/services/canton_summary_service.py
+++ b/cosomis/administrativelevels/services/canton_summary_service.py
@@ -14,13 +14,14 @@ class CantonSummaryService:
     """
 
     def __init__(self, canton: AdministrativeLevel):
-        assert canton.type == AdministrativeLevel.CANTON, (
-            f"Expected CANTON, got {canton.type}"
+        assert canton.is_canton(), (
+            f"Expected canton-type AdministrativeLevel, got type={canton.type!r}"
         )
         self._canton = canton
         self._child_villages = AdministrativeLevel.objects.filter(
             parent=canton,
-            type=AdministrativeLevel.VILLAGE
+        ).filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE),
         )
 
     def get_population_aggregates(self) -> dict:

--- a/cosomis/administrativelevels/tests/test_canton_planning_service.py
+++ b/cosomis/administrativelevels/tests/test_canton_planning_service.py
@@ -25,6 +25,7 @@ def _make_canton(pk=1, name="Test Canton"):
     c.pk = pk
     c.name = name
     c.type = AdministrativeLevel.CANTON
+    c.is_canton.return_value = True
     return c
 
 
@@ -33,6 +34,7 @@ def _make_village(pk, name):
     v.pk = pk
     v.name = name
     v.type = AdministrativeLevel.VILLAGE
+    v.is_canton.return_value = False
     return v
 
 

--- a/cosomis/administrativelevels/views.py
+++ b/cosomis/administrativelevels/views.py
@@ -516,11 +516,13 @@ class CommuneDetailView(PageMixin, LoginRequiredApproveRequiredMixin, DetailView
         # For Commune, include images from child cantons and grandchild villages
         child_cantons = AdministrativeLevel.objects.filter(
             parent=admin_level,
-            type=AdministrativeLevel.CANTON
+        ).filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.CANTON)
         )
         descendant_villages = AdministrativeLevel.objects.filter(
             parent__in=child_cantons,
-            type=AdministrativeLevel.VILLAGE
+        ).filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE)
         )
         all_descendants = AdministrativeLevel.objects.filter(
             Q(id=admin_level.id) |
@@ -868,7 +870,8 @@ class CantonDetailView(PageMixin, LoginRequiredApproveRequiredMixin, DetailView)
         # Keep existing villages queryset for the Villages tab
         context["villages"] = AdministrativeLevel.objects.filter(
             parent=canton,
-            type=AdministrativeLevel.VILLAGE
+        ).filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE)
         ).annotate(
             total_estimated_cost=Coalesce(Sum('investments__estimated_cost'), 0),
             total_founded=Coalesce(
@@ -883,7 +886,11 @@ class CantonDetailView(PageMixin, LoginRequiredApproveRequiredMixin, DetailView)
 
         base_priorities_qs = Investment.objects.filter(
             administrative_level__parent=canton,
-            administrative_level__type=AdministrativeLevel.VILLAGE,
+        ).filter(
+            AdministrativeLevel.type_filter_q(
+                AdministrativeLevel.VILLAGE,
+                field="administrative_level__type",
+            ),
         ).select_related(
             "administrative_level",
             "sector__category",
@@ -906,7 +913,11 @@ class CantonDetailView(PageMixin, LoginRequiredApproveRequiredMixin, DetailView)
             Investment.objects.filter(
                 project_status=Investment.NOT_FUNDED,
                 administrative_level__parent=canton,
-                administrative_level__type=AdministrativeLevel.VILLAGE,
+            ).filter(
+                AdministrativeLevel.type_filter_q(
+                    AdministrativeLevel.VILLAGE,
+                    field="administrative_level__type",
+                ),
             ).only(
                 "id", "ranking", "title", "description",
                 "endorsed_by_youth", "endorsed_by_women",
@@ -917,7 +928,11 @@ class CantonDetailView(PageMixin, LoginRequiredApproveRequiredMixin, DetailView)
 
         context["subprojects"] = Investment.objects.filter(
             administrative_level__parent=canton,
-            administrative_level__type=AdministrativeLevel.VILLAGE,
+        ).filter(
+            AdministrativeLevel.type_filter_q(
+                AdministrativeLevel.VILLAGE,
+                field="administrative_level__type",
+            ),
         ).exclude(project_status=Investment.NOT_FUNDED).only(
             "id", "ranking", "title", "description",
             "endorsed_by_youth", "endorsed_by_women",


### PR DESCRIPTION
#### What does this PR do?

`/en/administrative-levels/canton/<id>/` returned 500 on the Benin dataset because three Canton services hard-coded `assert canton.type == AdministrativeLevel.CANTON`. Benin stores the same logical levels under different French strings (`arrondissement`, `commune`, `département`, `village`), so the assertion blew up and the queryset filters in `CommuneDetailView` / `CantonDetailView` silently returned 0 villages.

Fix is centralized on the `AdministrativeLevel` model — no per-call-site alias lists:

- New `TYPE_ALIASES` dict on the model maps each canonical type (Village, Canton, Commune, Prefecture, Region) to all known stored spellings (e.g. `CANTON → ('canton', 'arrondissement')`, `PREFECTURE → ('prefecture', 'département', 'departement')`).
- New classmethods `aliases_for()`, `matches_type()`, and `type_filter_q(canonical_type, field='type')` — the last returns a `Q` of case-insensitive `iexact` lookups, suitable for both direct filters (`type=...`) and traversal lookups (`administrative_level__type=...`).
- Existing `is_village/canton/commune/region/prefecture()` helpers now flow through `matches_type()`; `get_current_task` and `get_villages_coordinates` now use `is_village()` instead of `self.type == self.VILLAGE`.
- The three Canton services (`canton_summary_service`, `canton_planning_service`, `canton_map_service`) replace `assert canton.type == AdministrativeLevel.CANTON` with `assert canton.is_canton()`, and rewrite their child-village filters via `type_filter_q()`.
- `CommuneDetailView` and `CantonDetailView` rewrite their `type=AdministrativeLevel.CANTON/VILLAGE` filters (including `administrative_level__type=…` traversals) the same way.
- Test factories in `test_canton_planning_service.py` stub `is_canton.return_value` on the `MagicMock(spec=AdministrativeLevel)` objects so the guard test still triggers (a bare MagicMock returns a truthy MagicMock from `is_canton()` otherwise).

Out of scope intentionally: `forms.py`, `utils/views.py`, management commands, and `AttachmentListView`'s region filter still use raw `type=…` filters. They're not on the canton/commune/prefecture render path; `type_filter_q()` is ready when those paths get exercised.

Caveats for reviewers: this fix only works for the country aliases declared in `TYPE_ALIASES` today (Togo + Benin). Loading a third country with different French/English terms means adding to that map. It also still bakes in a Togo-shaped 5-level hierarchy in the view querysets (`parent__parent=admin_level`, "commune → cantons → villages"). True country-agnostic behavior would need either a depth-from-root or a per-row `logical_level` enum — that's a bigger refactor.

#### How to verify functionality?
- [ ] Log in locally as `leo@local.dev / 123Qwerty!` and confirm all three return **200** with real content:
  - [ ] `/en/administrative-levels/canton/691/` — Benin arrondissement TCHOUMI-TCHOUMI, should list its 6 child villages
  - [ ] `/en/administrative-levels/commune/690/` — Benin commune NATITINGOU, should list its descendant villages (was previously empty)
  - [ ] `/en/administrative-levels/prefecture/601/` — Benin département ATACORA
- [ ] Smoke a Togo canton/commune detail page to confirm no regression on the original Togo dataset.
- [ ] `python manage.py test administrativelevels.tests` — all 89 tests in the touched files pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)