### PR TITLE
feat(administrativelevels): summary card + dataset-agnostic search & breadcrumbs

### DIFF
--- a/cosomis/.gitignore
+++ b/cosomis/.gitignore
@@ -1,3 +1,5 @@
+# Python virtual environment
+venv/
 
 # Elastic Beanstalk Files
 .elasticbeanstalk/*

--- a/cosomis/CHANGELOG.md
+++ b/cosomis/CHANGELOG.md
@@ -1,0 +1,71 @@
+# Changelog
+
+All notable user-visible and developer-facing changes are tracked here. The
+format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased] — 2026-05-17
+
+### Added
+
+- **Live summary card on `/administrative-levels/search/`.** Selecting any level
+  in the cascading filter (or a leaf radio) now fades in a sticky card on the
+  right with the entity's name, type badge, ancestor breadcrumb, direct-child
+  count using the dataset's own next-level vocabulary (e.g. "10 Arrondissements"
+  on Benin, "10 Cantons" on Togo), total descendant villages, **total
+  population** rolled up across the subtree, **total priorities**
+  (`investment_status = PRIORITY`), **projects funded**
+  (`project_status != NOT_FUNDED`), identified-priority date, coordinates and
+  code where available, and an "Open *<type>* profile" CTA that links to the
+  correct detail page (`AdministrativeLevelSummaryAjaxView` at
+  `administrativelevels:utils:administrative_level_summary`).
+- **`AdministrativeLevel.get_hierarchy_labels()`** classmethod that walks one
+  branch root → leaf and returns the dataset's actual level names. Drives the
+  search-page form labels, select2 placeholders, and "Choice the X in Y" /
+  "Open X profile" copy.
+- **Skeleton-shimmer loading affordances on `/investments/`.** The six metric
+  cards (available + selected totals) render animated placeholders instead of
+  static `0` / `0 FCFA` until the AJAX totals resolve, and refreshes (filter
+  change, select-all, checkbox toggles) re-paint skeletons in `beforeSend`.
+- **Centered DataTable overlay on `/investments/`.** Replaces DataTables'
+  built-in corner "Processing…" badge with a 44 px spinner + "Loading
+  investments…" copy, wired to the `processing.dt` event.
+
+### Changed
+
+- **Breadcrumb tag (`adm_breadcrumb`) is name-agnostic.** Was looking up the
+  detail URL by `item.type` against the Togo English constants — every
+  ancestor link broke on the Benin dataset. Now maps each ancestor to one of
+  five fixed routes (`region_detail` → `village_detail`) by position in the
+  parent chain. Works for any dataset whose hierarchy uses different
+  terminology and survives shorter chains (e.g. canton-rooted pages).
+- **Search page (`/administrative-levels/search/`) revamp.** Two-column layout
+  with cascading filters and village radios on the left, sticky summary card
+  on the right; the search box moved into the left card body; per-row "Check"
+  buttons removed (the card's CTA replaces them). The "Choice the village in
+  canton" heading and "See village" button now use `blocktranslate with` so
+  they reflect the dataset's leaf and parent-of-leaf labels.
+- **`VillageSearchForm`.** `region` queryset is now `parent__isnull=True`
+  (top-level entities, name-agnostic) instead of `type="Region"` (the original
+  matched 0 rows on Benin). `prefecture`/`commune`/`canton` start as
+  `objects.none()` since the cascading AJAX populates them at runtime. Added
+  `hierarchy_labels=` constructor kwarg so the view can override the four
+  field labels with the dataset's actual names.
+- **`AdministrativeLevelSearchListView` & `AdministrativeLevelsListView`
+  queryset.** Both `get_queryset()` methods now filter `type__iexact=` instead
+  of `type=`, and added `order_by("name")` to silence
+  `UnorderedObjectListWarning` and stabilise pagination.
+
+### Fixed
+
+- **Search page returned empty results on the Benin dataset.** The view
+  filtered `type="Village"` while the data stores `"village"` (lowercase) — 0
+  matches. Fixed by switching to `type__iexact` in both list views.
+- **Cascading region dropdown was empty on Benin.** Same root cause in the
+  `VillageSearchForm.region` queryset; switched to `parent__isnull=True`.
+- **Redundant "Villages" row on arrondissement-level summary cards.** Hidden
+  when the direct-children row already represents villages
+  (`next_level_label == "Village"`).
+
+### Developer
+
+- Added `venv/` to `cosomis/.gitignore`.

--- a/cosomis/CLAUDE.md
+++ b/cosomis/CLAUDE.md
@@ -1,0 +1,172 @@
+# CLAUDE.md — guidance for AI sessions in this repo
+
+This file orients Claude (and humans) before touching the code. Skim it before
+proposing changes. For local setup, see [README.md](./README.md). For change
+history, see [CHANGELOG.md](./CHANGELOG.md).
+
+## What this project is
+
+A Django 4.1 web app for managing community-driven development data:
+administrative hierarchies (country → … → village), investment proposals
+("priorities"), funding packages, planning cycles, and per-canton/commune
+profiles. Deployed against multiple country datasets — currently Togo and
+Benin — that share schema but **not** vocabulary.
+
+## Workspace layout
+
+You'll usually be in `cosomis/` (the Django project root, where `manage.py`
+lives). Anything above that is a thin GitLab-template shell.
+
+```
+cosomis/
+├── administrativelevels/   # Hierarchy, search, profiles, maps
+├── authentication/         # Login flows
+├── cdd_funnel/             # CDD funnel views
+├── cosomis/                # settings, root URLs, shared mixins/services
+├── dashboard/
+├── investments/            # Investments, packages, cart, moderator/investor
+├── usermanager/            # Custom User + Organization
+├── utils/
+├── static/AdminLTE/        # Theme + plugins (Bootstrap 4 era)
+├── locale/{en,fr}/         # i18n catalogs
+├── templates/layouts/      # base/head/navbar/sidebar
+└── requirements.txt
+```
+
+## Stack quick reference
+
+- **Django 4.1.1** — pinned for the rest of the stack; do not bump casually.
+- **Python 3.11** — the only interpreter the pinned `numpy==1.23.3` /
+  `pandas==1.5.0` build for. 3.12/3.13 fail.
+- **PostgreSQL 16** in production; SQLite locally if `env=dev`. The dev dump
+  is custom-format and restores via `pg_restore` (see README).
+- **Custom user model** `usermanager.User` (`AbstractUser` subclass) with
+  `USERNAME_FIELD = "email"` — `createsuperuser` and `Client.login()` both
+  take `email=...`, not `username=...`.
+- **Frontend** is jQuery + Bootstrap 4 + AdminLTE + select2 + DataTables.
+  Newer code mixes in **HTMX** (`django_htmx` in `INSTALLED_APPS`,
+  `HtmxMiddleware` in `MIDDLEWARE`) — prefer it for new fragment-swap UX over
+  hand-rolled jQuery `$.ajax`.
+- **i18n** is mandatory: every user-facing string goes through `{% translate %}`
+  / `gettext_lazy` / `blocktranslate`. URLs are language-prefixed (`/en/…`,
+  `/fr/…`). Run `make generate-translations` after adding strings.
+
+## Conventions that bite if you ignore them
+
+### 1. Administrative-level `type` strings are dataset-specific
+
+`AdministrativeLevel.type` is **not** a fixed vocabulary. Each country dump
+labels the same logical level differently:
+
+| Depth | Togo seed | Benin dump |
+| --- | --- | --- |
+| Root (0) | `Region` | `country` |
+| 1 | `Prefecture` | `département` |
+| 2 | `Commune` | `commune` |
+| 3 | `Canton` | `arrondissement` |
+| Leaf (4) | `Village` | `village` |
+
+Casing differs too (`Village` vs `village`). The model exposes the right
+primitives — **use them, never hard-code a literal**:
+
+- `AdministrativeLevel.matches_type(stored, canonical)` — case-insensitive,
+  alias-aware boolean test.
+- `AdministrativeLevel.type_filter_q(canonical, field="type")` — `Q()`
+  expression for ORM filters that matches every alias.
+- `AdministrativeLevel.aliases_for(canonical)` — raw alias tuple.
+- `is_village()`, `is_canton()`, `is_commune()`, `is_prefecture()`,
+  `is_region()` — instance helpers.
+- `AdministrativeLevel.get_hierarchy_labels()` — returns the dataset's own
+  level names root-first, for UI labels.
+- `TYPE_ALIASES` (on the model) — the canonical alias map; extend here when
+  onboarding a new country.
+
+For things that aren't a "which type is this" question but a "which level
+is this in the hierarchy", **prefer position-based logic** (walk parents to
+get depth, then map to one of the five fixed routes). The breadcrumb tag
+and the summary-card detail-URL resolver both do this.
+
+**Past incidents** caused by hard-coded type strings, all fixed:
+
+- `adm_breadcrumb` rendered every ancestor as plain text on Benin because
+  `url_map.get(item.type)` missed (`'Village'` vs `'village'`,
+  `'Canton'` vs `'arrondissement'`).
+- `AdministrativeLevelSearchListView.get_queryset` filtered `type='Village'`
+  and returned zero rows on Benin.
+- `VillageSearchForm.region` queryset was empty for the same reason.
+- `CantonSummaryService.__init__` still asserts
+  `canton.type == AdministrativeLevel.CANTON`. There is a follow-up task
+  open for this — see git log around `claude/eager-kare-0ed0de`.
+
+### 2. `.env` lives at `cosomis/cosomis/.env`
+
+`settings.py` calls `env.read_env()` with no args; `django-environ` resolves
+the path relative to the file calling it, so the `.env` must sit **next to
+`settings.py`**, not at the project root. The repo `.gitignore` covers both
+locations.
+
+### 3. The investments page uses server-side DataTables
+
+`/investments/` builds a DataTable in JS using `datatable_config` from the
+view, with `serverSide: true` and AJAX-loaded totals. Two totals AJAX calls
+fire on load (`init_total_values`, `sum_subprojects`); both now paint
+skeleton placeholders in `beforeSend` rather than leaving stale `0`s on
+screen. If you add metrics, follow the same pattern (skeleton in
+`beforeSend`, real value in `success`, `—` in `error`).
+
+### 4. Don't write multi-line `{# ... #}` template comments
+
+Django only supports single-line `{# ... #}`. Use `{% comment %}…{% endcomment %}`
+for anything longer. (Multi-line `{# ... #}` renders as literal text in the
+output, which already shipped to a user once.)
+
+### 5. Custom user model is email-keyed
+
+```python
+User.objects.create_superuser(email="x@y.com", username="x", password="…")
+# In tests: Client().login(email="x@y.com", password="…")
+```
+
+## How work usually ships
+
+- `develop2` is the shared integration branch — most feature PRs merge there.
+- Branch from `develop2`, prefix with `claude/` (Claude work) or `feature/`
+  (human work), open the PR back to `develop2`.
+- Commits use Conventional Commits style: `feat(scope): …`, `fix(scope): …`,
+  `i18n: …`, etc. See `git log` for examples.
+
+## External integrations to know about (mostly stubbed locally)
+
+`settings.py` reads many env vars with no defaults — locally these point at
+`example.invalid` / placeholders and the calling code swallows the resulting
+exceptions:
+
+- **Mapbox** (`MAPBOX_ACCESS_TOKEN`) — maps fall back gracefully if blank.
+- **CouchDB** (`NO_SQL_*`) — only hit by some NoSQL views.
+- **S3** (`S3_*`) — `DEFAULT_FILE_STORAGE` is S3-backed; locally uploads
+  will fail. Most flows don't touch uploads.
+- **Mixpanel** (`MIXPANEL_*`) — `Error tracking event: Mixpanel error: $token,
+  missing or empty` in logs is benign.
+- **GRM** (`GRM_*`) — the administrative-level detail view tries to fetch
+  complaints; expect `Error fetching data from GRM API: …` in the log.
+- **MIS** (`MIS_*`) — similar.
+
+These shouldn't block local development; if your task needs one of them, set
+the corresponding env var.
+
+## Testing the UI
+
+There is no headless E2E suite wired up for this app. After a change, hit the
+affected page with `Client().login(email=…)` + `c.get(…)` from
+`manage.py shell` to confirm status codes and rendered fragments. For browser
+verification, use the dev server and check the actual page — type-coupling
+bugs surface only against a real dataset.
+
+## When you're unsure
+
+- Read the model first — many methods (`is_village()`, `get_villages_coordinates()`,
+  `get_all_descendants()`, `type_filter_q()`) already exist.
+- Check `administrativelevels/templatetags/custom_tags.py` for existing
+  template-tag patterns before adding a new one.
+- Default to **position in hierarchy** over **type string** for any logic
+  that conceptually means "what level is this".

--- a/cosomis/README.md
+++ b/cosomis/README.md
@@ -1,21 +1,105 @@
-### Run server
+# COSOMIS — Local Development Portal
 
-Run `make server`
+Django application for managing community-driven development data (administrative levels, investments, planning cycles) across multiple country datasets (Togo, Benin, …).
 
-### Update requirements
+## Quick start
 
-Run `make pip-install`
+### 1. Install dependencies
 
-### Generate translations
+The pinned versions (`Django 4.1.1`, `numpy==1.23.3`, `pandas==1.5.0`, etc.) only have wheels for **Python 3.11**. Newer interpreters fail to build numpy from source.
 
-To  update the translations and generate the .po and .mo
-Run `make generate-transalations`
+```bash
+/opt/homebrew/opt/python@3.11/bin/python3.11 -m venv venv
+./venv/bin/pip install --upgrade pip
+./venv/bin/pip install -r requirements.txt
+```
 
-### Format the code with Black
+### 2. Configure environment
 
-You need to install Black first in your environment (https://github.com/psf/black)
+Create `cosomis/.env` (lives next to `settings.py`; `django-environ` looks there) — start from [`env.example`](./env.example) and set at minimum:
 
-Then, run `make black`
+```
+env=local
+SECRET_KEY=local-dev-secret
+DEBUG=True
+ALLOWED_HOSTS=*
+DATABASE_URL=postgres://admin:admin@localhost:5434/ldpdb
+LEGACY_DATABASE_URL=postgres://admin:admin@localhost:5434/ldpdb
+EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+FRONTEND_URL_ROOT=http://127.0.0.1:8000
+```
 
-In Pycharm, you can configure it in the Tools sections
+(Set `env=dev` to fall back to the bundled SQLite file instead of Postgres.)
 
+### 3. Bring up Postgres + restore a dump
+
+The project targets PostgreSQL 16. An isolated Docker container keeps it out of the way of any other Postgres you have running locally.
+
+```bash
+docker run -d \
+  --name ldp-postgres \
+  -e POSTGRES_USER=admin -e POSTGRES_PASSWORD=admin -e POSTGRES_DB=ldpdb \
+  -p 5434:5432 \
+  -v ldp-postgres-data:/var/lib/postgresql/data \
+  postgres:16
+
+# Restore a custom-format dump (e.g. ldpdb11052026.dump)
+docker exec -i ldp-postgres pg_restore \
+  -U admin -d ldpdb \
+  --no-owner --no-privileges --clean --if-exists \
+  < ~/Downloads/ldpdb11052026.dump
+```
+
+### 4. Apply pending migrations and run the server
+
+```bash
+./venv/bin/python manage.py migrate
+./venv/bin/python manage.py runserver
+# or equivalently:
+make server
+```
+
+Open <http://127.0.0.1:8000/>. The site uses `django-modeltranslation`-style URLs prefixed with `/en/` or `/fr/`.
+
+### 5. Create a local superuser
+
+The custom user model uses `email` as `USERNAME_FIELD`:
+
+```bash
+./venv/bin/python manage.py shell -c "
+from usermanager.models import User
+u = User.objects.create_superuser(email='you@local.dev', username='you', password='change-me')
+print(u)
+"
+```
+
+## Common commands
+
+| Task | Command |
+| --- | --- |
+| Run the dev server (migrate first) | `make server` |
+| Update Python deps | `make pip-install` |
+| Regenerate `.po`/`.mo` files | `make generate-translations` |
+| Format Python with Black | `make black` |
+
+## Project layout
+
+```
+cosomis/                  # Django project root (manage.py lives here)
+├── administrativelevels/ # Country/region/village hierarchy, search, profiles, maps
+├── authentication/       # Auth flows
+├── cdd_funnel/           # Community-Driven Development funnel views
+├── cosomis/              # Project settings, root URLs, shared mixins/services
+├── dashboard/            # Dashboard views
+├── investments/          # Investments, packages, cart, moderator/investor flows
+├── usermanager/          # Custom User + Organization
+├── utils/                # Cross-app utilities
+├── static/               # AdminLTE + project static assets
+├── locale/               # i18n catalogs (en/fr)
+└── requirements.txt
+```
+
+## Notes
+
+- Administrative-level type strings are **dataset-specific** (`Village/Canton/Commune/Prefecture/Region` on the Togo seed; `village/arrondissement/commune/département/country` on the Benin dump). Code must go through `AdministrativeLevel.matches_type()`, `type_filter_q()`, or position-based logic (depth in the hierarchy) — never hard-code a type literal. See [`CLAUDE.md`](./CLAUDE.md) for the full guidance.
+- See [`CHANGELOG.md`](./CHANGELOG.md) for the change history.

--- a/cosomis/administrativelevels/forms.py
+++ b/cosomis/administrativelevels/forms.py
@@ -171,27 +171,46 @@ class AdministrativeLevelForm(forms.ModelForm):
 
 # SearchVillages
 class VillageSearchForm(forms.Form):
+    # Top-level (root) entities — identified by absence of a parent rather than by
+    # the localized `type` string, so the form works regardless of whether the
+    # dataset labels its root as "Region" (Togo) or "country" (Benin), etc.
     region = forms.ModelChoiceField(
-        queryset=AdministrativeLevel.objects.filter(type="Region"),
+        queryset=AdministrativeLevel.objects.filter(parent__isnull=True),
         required=False,
         empty_label=_("All regions"),
         label=_("Region"),
     )
+    # The remaining levels are populated dynamically by the cascading AJAX in
+    # the template (parent_id-based), so the initial queryset is empty by design.
     prefecture = forms.ModelChoiceField(
-        queryset=AdministrativeLevel.objects.filter(type="Prefecture"),
+        queryset=AdministrativeLevel.objects.none(),
         required=False,
         label=_("Prefecture"),
     )
     commune = forms.ModelChoiceField(
-        queryset=AdministrativeLevel.objects.filter(type="Commune"),
+        queryset=AdministrativeLevel.objects.none(),
         required=False,
         label=_("Commune"),
     )
     canton = forms.ModelChoiceField(
-        queryset=AdministrativeLevel.objects.filter(type="Canton"),
+        queryset=AdministrativeLevel.objects.none(),
         required=False,
         label=_("Canton"),
     )
+
+    def __init__(self, *args, hierarchy_labels=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        # `hierarchy_labels` is root-first: [region, prefecture, commune, canton, leaf].
+        # Override the static labels with whatever the dataset actually calls each
+        # level (Country/Département/Commune/Arrondissement on the Benin dataset,
+        # Region/Prefecture/Commune/Canton on Togo, etc.).
+        if hierarchy_labels:
+            for field_name, label in zip(
+                ("region", "prefecture", "commune", "canton"),
+                hierarchy_labels,
+            ):
+                if label and field_name in self.fields:
+                    self.fields[field_name].label = label
 
 class FinancialPartnerForm(forms.Form):
     name = forms.CharField()

--- a/cosomis/administrativelevels/models.py
+++ b/cosomis/administrativelevels/models.py
@@ -146,6 +146,29 @@ class AdministrativeLevel(BaseModel):
             q |= Q(**{f"{field}__iexact": alias})
         return q
 
+    @classmethod
+    def get_hierarchy_labels(cls):
+        """Return the dataset's actual level names, root-first.
+
+        Walks one branch from the root down (root -> first child -> first
+        grandchild ...) and collects each node's `type` string. The result
+        reflects what the data actually calls each depth (Country / Département
+        / Commune / Arrondissement / Village for Benin, Region / Prefecture /
+        Commune / Canton / Village for Togo, etc.) so UI labels can be driven
+        by the data instead of being hard-coded.
+        """
+        root = cls.objects.filter(parent__isnull=True).first()
+        if not root:
+            return []
+        labels = []
+        cur = root
+        seen = set()
+        while cur and cur.id not in seen:
+            labels.append((cur.type or "").strip().capitalize())
+            seen.add(cur.id)
+            cur = cur.children.first()
+        return labels
+
     def is_village(self):
         return self.matches_type(self.type, self.VILLAGE)
 

--- a/cosomis/administrativelevels/templates/administrative_level/list.html
+++ b/cosomis/administrativelevels/templates/administrative_level/list.html
@@ -1,79 +1,180 @@
 {% extends 'layouts/base.html' %}
 {% load static i18n custom_tags %}
 
+{% block extracss %}
+    {{ block.super }}
+    <style>
+        /* --- Summary card styling --- */
+        .adm-summary-wrapper {
+            position: sticky;
+            top: 80px;
+        }
+        .adm-summary {
+            background: linear-gradient(135deg, #ffffff 0%, #f7f9fc 100%);
+            border: 1px solid #e3e6f0;
+            border-radius: 10px;
+            padding: 24px;
+            box-shadow: 0 4px 16px rgba(52, 152, 219, 0.08);
+            animation: adm-summary-in .25s ease;
+        }
+        @keyframes adm-summary-in {
+            from { opacity: 0; transform: translateY(6px); }
+            to   { opacity: 1; transform: translateY(0); }
+        }
+        .adm-summary--empty {
+            text-align: center;
+            padding: 56px 24px;
+            border: 2px dashed #d6dbe4;
+            background: #fafbfd;
+            color: #8a93a3;
+        }
+        .adm-summary--empty .adm-summary__icon {
+            font-size: 42px;
+            color: #c4ccd9;
+            margin-bottom: 12px;
+        }
+        .adm-summary--loading {
+            text-align: center;
+            padding: 56px 24px;
+            color: #6c757d;
+        }
+        .adm-summary--loading .spinner {
+            width: 36px;
+            height: 36px;
+            border: 4px solid #e3e3e3;
+            border-top-color: #3498db;
+            border-radius: 50%;
+            animation: adm-rot .8s linear infinite;
+            margin: 0 auto 14px;
+        }
+        @keyframes adm-rot {
+            to { transform: rotate(360deg); }
+        }
+
+        .adm-summary__path {
+            font-size: 12px;
+            color: #8a93a3;
+            margin-bottom: 8px;
+            line-height: 1.6;
+        }
+        .adm-summary__path i { font-size: 8px; margin: 0 4px; opacity: .6; }
+
+        .adm-summary__type {
+            display: inline-block;
+            background: #3498db;
+            color: #fff;
+            padding: 3px 12px;
+            border-radius: 12px;
+            font-size: 10px;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: .8px;
+        }
+        .adm-summary__name {
+            font-size: 26px;
+            font-weight: 700;
+            margin: 10px 0 20px;
+            color: #2c3e50;
+            line-height: 1.2;
+            word-break: break-word;
+        }
+        .adm-summary__stats {
+            margin: 0 0 20px;
+            padding: 0;
+        }
+        .adm-summary__stats > div {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 10px 0;
+            border-bottom: 1px solid #eef0f4;
+        }
+        .adm-summary__stats > div:last-child { border-bottom: none; }
+        .adm-summary__stats dt {
+            color: #6c757d;
+            font-weight: 500;
+            font-size: 13px;
+            margin: 0;
+            display: flex;
+            align-items: center;
+        }
+        .adm-summary__stats dt i {
+            width: 18px;
+            color: #3498db;
+            margin-right: 8px;
+            font-size: 12px;
+        }
+        .adm-summary__stats dd {
+            font-weight: 600;
+            color: #2c3e50;
+            margin: 0;
+            font-size: 14px;
+        }
+        .adm-summary__cta {
+            font-weight: 600;
+            letter-spacing: .3px;
+        }
+
+        /* Compact form rows so the left column stays balanced with the card */
+        .adl-filter .form-group { margin-bottom: 0.75rem; }
+    </style>
+{% endblock %}
+
 {% block content %}
     <div class="row">
-        <div class="col-12">
+        <!-- Left column: cascading filters + village list -->
+        <div class="col-md-7">
             <div class="card">
                 <div class="card-body">
-                    <div class="col-3 pull-right" style="display: inline-block;">
-                        <form method="get" class="d-flex">
-
-                            <div class="input-group input-group-sm">
-                            	<input type="hidden" name="type" value="{{ type }}">
-                            	<input class="form-control" name="search"
-                            	placeholder="{% translate 'Search a level' %}...">
-								<span class="input-group-append">
-									<button type="button" class="btn btn-default btn-flat">
-										<i class="fas fa-search"></i>
-									</button>
-								</span>
-							</div>
-
-                        </form>
-                    </div>
-                    <div class="col-9 justify-content-left">
-                    <div class="row">
-                        <div class="col-12 adl-filter">
-                            {% for field in form %}
-                            <div class="form-group row">
-                                <label class="col-3 col-form-label">{{ field.label }}</label>
-                                <div class="col-6">
-                                    {{ field }}
-                                </div>
-                                <div class="col-3">
-                                 <a id="check_{{ field.name }}" href="" class="btn btn-primary" style="display: none;">{% translate 'Check' %}</a>
-                                </div>
-                                {% comment%}
-                                <div class="col-3" >
-                                    <span class="_mobile"><i class="fa fa-eye"></i></span>
-                                    <a id="profil">{{field.label}}</a>
-                                </div>
-                                {% endcomment %}
-                                {% if field.errors %}
-                                <div class="alert alert-danger alert-sm form_alert">{{ field.errors }}</div>
-                                {% endif %}
-                                <div class="clearfix"></div>
-                            </div>
-                            {% endfor %}
+                    <form method="get" class="d-flex mb-3">
+                        <div class="input-group input-group-sm">
+                            <input type="hidden" name="type" value="{{ type }}">
+                            <input class="form-control" name="search"
+                                value="{{ search|default_if_none:'' }}"
+                                placeholder="{% translate 'Search a level' %}...">
+                            <span class="input-group-append">
+                                <button type="submit" class="btn btn-default btn-flat">
+                                    <i class="fas fa-search"></i>
+                                </button>
+                            </span>
                         </div>
+                    </form>
 
+                    <div class="adl-filter">
+                        {% for field in form %}
+                            <div class="form-group row">
+                                <label class="col-4 col-form-label">{{ field.label }}</label>
+                                <div class="col-8">{{ field }}</div>
+                                <a id="check_{{ field.name }}" href="" style="display: none;"></a>
+                                {% if field.errors %}
+                                    <div class="alert alert-danger alert-sm form_alert">{{ field.errors }}</div>
+                                {% endif %}
+                            </div>
+                        {% endfor %}
                     </div>
-                    </div>
 
-                     <strong id="villages_title">{% translate 'Choice the village in canton' %} : </strong><br>
-                    <div id="search_results">
-
-                    </div>
-                    <a
-                        class="btn btn-primary pull right" style="display: none;"
-                        type="button" id="seeVillage"
-                        href="#"
-
-                    >
-                        {% translate 'See village' %}
-                    </a>
-
+                    <strong id="villages_title" class="d-block mt-3">
+                        {% blocktranslate with leaf=leaf_label parent=parent_of_leaf_label %}Choice the {{ leaf }} in {{ parent }}{% endblocktranslate %} :
+                    </strong>
+                    <div id="search_results" class="mt-2"></div>
+                    <a id="seeVillage" href="#" style="display: none;"></a>
                 </div>
-                <div>
+            </div>
+        </div>
 
-
+        <!-- Right column: live summary card -->
+        <div class="col-md-5">
+            <div class="adm-summary-wrapper">
+                <div id="adm-summary-card">
+                    <div class="adm-summary adm-summary--empty">
+                        <div class="adm-summary__icon"><i class="fas fa-map-marked-alt"></i></div>
+                        <p class="mb-0">{% translate 'Pick a level on the left to see a summary here.' %}</p>
+                    </div>
                 </div>
-
             </div>
         </div>
     </div>
-    {% endblock %}
+{% endblock %}
 
     {% block javascript %}
     {{ block.super }}
@@ -81,6 +182,36 @@
     <script type="text/javascript">
 
         var url_village= "";
+
+        // --- Summary card helpers ------------------------------------------------
+        const SUMMARY_URL_TPL = "{% url 'administrativelevels:utils:administrative_level_summary' 0 %}";
+        const SUMMARY_EMPTY_HTML = `
+            <div class="adm-summary adm-summary--empty">
+                <div class="adm-summary__icon"><i class="fas fa-map-marked-alt"></i></div>
+                <p class="mb-0">{% translate 'Pick a level on the left to see a summary here.' %}</p>
+            </div>`;
+        const SUMMARY_LOADING_HTML = `
+            <div class="adm-summary adm-summary--loading">
+                <div class="spinner"></div>
+                <div>{% translate 'Loading summary…' %}</div>
+            </div>`;
+
+        let summaryRequest = null;
+        function loadAdmSummary(id) {
+            const $card = $('#adm-summary-card');
+            if (!id) { $card.html(SUMMARY_EMPTY_HTML); return; }
+            if (summaryRequest) { summaryRequest.abort(); }
+            $card.html(SUMMARY_LOADING_HTML);
+            summaryRequest = $.ajax({
+                type: 'GET',
+                url: SUMMARY_URL_TPL.replace(/0\/$/, id + '/'),
+                success: function (html) { $card.html(html); },
+                error: function (xhr) {
+                    if (xhr.statusText === 'abort') return;
+                    $card.html(`<div class="adm-summary adm-summary--empty"><p class="mb-0 text-danger">{% translate 'Could not load summary.' %}</p></div>`);
+                }
+            });
+        }
 
         function set_datas(element, data) {
 
@@ -120,6 +251,9 @@
                         document.getElementById(identifier).style.display = "block";
                         let url = `{% url 'administrativelevels:list' %}` + type + '/' + $(this).val();
                         document.getElementById(identifier).setAttribute('href', url);
+
+                        // Update the right-hand summary card with whatever was just selected.
+                        loadAdmSummary($(this).val());
 
                         $.ajax({
                             type: 'GET',
@@ -172,10 +306,9 @@
                                     $(".radio-button-search").click(function(event){
                                        let url = `{% url "administrativelevels:village_detail" 0 %}`.replace('0', this.value);
                                         url_village = url;
-                                        document.getElementById("seeVillage").style.display = "block";
-                                        //window.location.href = url;
-                                        document.getElementById("seeVillage").disabled = false;
                                         document.getElementById("seeVillage").setAttribute('href', url);
+                                        // Refresh the summary card to reflect the selected village.
+                                        loadAdmSummary(this.value);
                                     });
                                     if(url_village == ""){
                                         document.getElementById("seeVillage").disabled = true;
@@ -218,6 +351,10 @@
                                 document.getElementById("search_results").style.display = "none";
                             }
                         }
+                        // Clearing the top-most select fully resets the picker, so empty the card too.
+                        if (next_index === 0) {
+                            loadAdmSummary(null);
+                        }
                     }
 
                 });
@@ -230,24 +367,24 @@
 <script type="text/javascript">
     $("#id_region").select2({
         language: '{{ current_language }}',
-        placeholder: "{% translate 'Region' %}",
+        placeholder: "{{ form.region.label|default:_('Region') }}",
         allowClear: true,
         width: 'inherit'
     });
     $("#id_prefecture").select2({
-        placeholder: "{% translate 'Prefecture' %}",
+        placeholder: "{{ form.prefecture.label|default:_('Prefecture') }}",
         language: '{{ current_language }}',
         allowClear: true,
         width: 'inherit'
     });
     $("#id_commune").select2({
-        placeholder: "{% translate 'Commune' %}",
+        placeholder: "{{ form.commune.label|default:_('Commune') }}",
         language: '{{ current_language }}',
         allowClear: true,
         width: 'inherit'
     });
     $("#id_canton").select2({
-        placeholder: "{% translate 'Canton' %}",
+        placeholder: "{{ form.canton.label|default:_('Canton') }}",
         language: '{{ current_language }}',
         allowClear: true,
         width: 'inherit'

--- a/cosomis/administrativelevels/templates/administrative_level/partials/summary_card.html
+++ b/cosomis/administrativelevels/templates/administrative_level/partials/summary_card.html
@@ -1,0 +1,70 @@
+{% load i18n humanize %}
+<div class="adm-summary">
+    {% if breadcrumb %}
+        <div class="adm-summary__path">
+            {% for ancestor in breadcrumb %}
+                <span>{{ ancestor.name }}</span>{% if not forloop.last %} <i class="fas fa-chevron-right"></i> {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
+
+    <span class="adm-summary__type">{{ type_label }}</span>
+    <h3 class="adm-summary__name" title="{{ adm.name }}">{{ adm.name }}</h3>
+
+    <dl class="adm-summary__stats">
+        {% if children_count %}
+            <div>
+                <dt>
+                    <i class="fas fa-sitemap"></i>
+                    {% if next_level_label %}{{ next_level_label }}s{% else %}{% translate 'Children' %}{% endif %}
+                </dt>
+                <dd>{{ children_count|intcomma }}</dd>
+            </div>
+        {% endif %}
+        {% if total_villages and total_villages > 1 and next_level_label != "Village" %}
+            <div>
+                <dt><i class="fas fa-home"></i> {% translate 'Villages' %}</dt>
+                <dd>{{ total_villages|intcomma }}</dd>
+            </div>
+        {% endif %}
+        {% if has_population %}
+            <div>
+                <dt><i class="fas fa-users"></i> {% translate 'Total population' %}</dt>
+                <dd>{{ total_population|intcomma }}</dd>
+            </div>
+        {% endif %}
+        <div>
+            <dt><i class="fas fa-flag"></i> {% translate 'Total priorities' %}</dt>
+            <dd>{{ total_priorities|intcomma }}</dd>
+        </div>
+        <div>
+            <dt><i class="fas fa-hand-holding-usd"></i> {% translate 'Projects funded' %}</dt>
+            <dd>{{ total_projects_funded|intcomma }}</dd>
+        </div>
+        {% if adm.identified_priority %}
+            <div>
+                <dt><i class="far fa-calendar-check"></i> {% translate 'Priority identified' %}</dt>
+                <dd>{{ adm.identified_priority|date:"d M Y" }}</dd>
+            </div>
+        {% endif %}
+        {% if has_coordinates %}
+            <div>
+                <dt><i class="fas fa-map-marker-alt"></i> {% translate 'Coordinates' %}</dt>
+                <dd>{{ adm.latitude|floatformat:4 }}, {{ adm.longitude|floatformat:4 }}</dd>
+            </div>
+        {% endif %}
+        {% if adm.code_loc %}
+            <div>
+                <dt><i class="fas fa-fingerprint"></i> {% translate 'Code' %}</dt>
+                <dd>{{ adm.code_loc }}</dd>
+            </div>
+        {% endif %}
+    </dl>
+
+    {% if detail_url %}
+        <a href="{{ detail_url }}" class="btn btn-primary btn-block adm-summary__cta">
+            {% blocktranslate with type=type_label %}Open {{ type }} profile{% endblocktranslate %}
+            <i class="fas fa-arrow-right ml-2"></i>
+        </a>
+    {% endif %}
+</div>

--- a/cosomis/administrativelevels/templatetags/custom_tags.py
+++ b/cosomis/administrativelevels/templatetags/custom_tags.py
@@ -14,38 +14,50 @@ from cosomis.utils import structure_the_words as utils_structure_the_words
 register = template.Library()
 
 
+# Detail routes from root down to leaf. The breadcrumb is name-agnostic:
+# whatever the `type` strings happen to be (Village/Canton vs village/arrondissement,
+# English vs French, etc.), the route for each ancestor is chosen by its position
+# in the chain. Index 0 is the root, index -1 is the leaf.
+_BREADCRUMB_ROUTES_ROOT_TO_LEAF = [
+    'administrativelevels:region_detail',
+    'administrativelevels:prefecture_detail',
+    'administrativelevels:commune_detail',
+    'administrativelevels:canton_detail',
+    'administrativelevels:village_detail',
+]
+
+
 @register.simple_tag
 def adm_breadcrumb(adm_level):
     """
-    Generate a breadcrumb hierarchy for an administrative level.
-    Example output: REGION > PREFECTURE > COMMUNE > CANTON > VILLAGE
-    Each parent is a clickable link to its detail page.
+    Generate a clickable breadcrumb for an administrative level by walking
+    the parent chain. The level just above the leaf is rendered with the
+    canton route, two above with the commune route, and so on — the `type`
+    string is not consulted, so datasets that label levels differently
+    (e.g. arrondissement instead of canton) still get correct links.
     """
-    # Map type to URL name
-    url_map = {
-        AdministrativeLevel.VILLAGE: 'administrativelevels:village_detail',
-        AdministrativeLevel.CANTON: 'administrativelevels:canton_detail',
-        AdministrativeLevel.COMMUNE: 'administrativelevels:commune_detail',
-        AdministrativeLevel.PREFECTURE: 'administrativelevels:prefecture_detail',
-        AdministrativeLevel.REGION: 'administrativelevels:region_detail',
-    }
-
-    # Build the chain from current to root
+    # Walk leaf -> root, then reverse so index 0 is the root.
     chain = []
     current = adm_level
     while current is not None:
         chain.append(current)
         current = current.parent
-
-    # Reverse so root is first
     chain.reverse()
+
+    # Align the chain to the leaf end of the fixed route list, so the deepest
+    # item always maps to the leaf route regardless of how short the chain is.
+    offset = len(_BREADCRUMB_ROUTES_ROOT_TO_LEAF) - len(chain)
 
     parts = []
     for i, item in enumerate(chain):
         is_last = (i == len(chain) - 1)
-        url_name = url_map.get(item.type)
+        route_idx = i + offset
+        url_name = (
+            _BREADCRUMB_ROUTES_ROOT_TO_LEAF[route_idx]
+            if 0 <= route_idx < len(_BREADCRUMB_ROUTES_ROOT_TO_LEAF)
+            else None
+        )
         if is_last:
-            # Current level: bold, no link
             parts.append(f'<span class="font-weight-bold">{item.name}</span>')
         elif url_name:
             url = reverse(url_name, args=[item.id])

--- a/cosomis/administrativelevels/utils/urls.py
+++ b/cosomis/administrativelevels/utils/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
      #      name='get_choices_for_next_administrative_level_by_geographical_unit'),
     path('get-ancestor-administrative-levels', views.GetAncestorAdministrativeLevelsView.as_view(),
          name='get_ancestor_administrative_levels'),
+    path('administrative-level-summary/<int:pk>/', views.AdministrativeLevelSummaryAjaxView.as_view(),
+         name='administrative_level_summary'),
     path('task-detail/<int:pk>', views.TaskDetailAjaxView.as_view(), name='task_detail'),
     path('attachments-filter', views.FillAttachmentSelectFilters.as_view(), name='attachment_filter'),
     path('sectors-codes', views.SectorCodesXLSXView.as_view(), name='sectors_codes'),

--- a/cosomis/administrativelevels/utils/views.py
+++ b/cosomis/administrativelevels/utils/views.py
@@ -4,14 +4,17 @@ import json
 import geojson
 import os
 import subprocess
-from django.db.models import Subquery
+from django.db.models import Subquery, Sum
+from django.urls import reverse, NoReverseMatch
 from django.views import generic
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
+from django.template.loader import render_to_string
 from openpyxl import Workbook
 from rest_framework import generics, response
 
 from cosomis.mixins import AJAXRequestMixin, JSONResponseMixin, LoginRequiredApproveRequiredMixin
 from administrativelevels.models import AdministrativeLevel, Phase, Activity, Task, Sector, GeoSegment
+from investments.models import Investment
 
 
 class GetAdministrativeLevelForCVDByADLView(AJAXRequestMixin, LoginRequiredApproveRequiredMixin, JSONResponseMixin, generic.View):
@@ -78,6 +81,98 @@ class GetAncestorAdministrativeLevelsView(AJAXRequestMixin, LoginRequiredApprove
             pass
 
         return self.render_to_json_response(ancestors, safe=False)
+
+
+class AdministrativeLevelSummaryAjaxView(AJAXRequestMixin, LoginRequiredApproveRequiredMixin, generic.View):
+    """Render a compact summary card for any administrative level.
+
+    Returns an HTML fragment (not JSON) that the search page swaps into its
+    sidebar whenever the user selects a level. The detail-page URL is picked
+    by depth-from-root, mirroring the breadcrumb logic, so the link works
+    regardless of how the dataset spells each level's `type`.
+    """
+
+    DETAIL_ROUTES_ROOT_TO_LEAF = [
+        'administrativelevels:region_detail',
+        'administrativelevels:prefecture_detail',
+        'administrativelevels:commune_detail',
+        'administrativelevels:canton_detail',
+        'administrativelevels:village_detail',
+    ]
+
+    def get(self, request, pk, *args, **kwargs):
+        try:
+            adm = AdministrativeLevel.objects.select_related('parent').get(id=pk)
+        except AdministrativeLevel.DoesNotExist:
+            raise Http404
+
+        depth = 0
+        cur = adm.parent
+        while cur is not None:
+            depth += 1
+            cur = cur.parent
+
+        detail_url = None
+        if 0 <= depth < len(self.DETAIL_ROUTES_ROOT_TO_LEAF):
+            try:
+                detail_url = reverse(self.DETAIL_ROUTES_ROOT_TO_LEAF[depth], args=[adm.id])
+            except NoReverseMatch:
+                detail_url = None
+
+        children_qs = adm.children.all()
+        children_count = children_qs.count()
+        sample_child = children_qs.first()
+        next_level_label = (sample_child.type or '').strip().capitalize() if sample_child else ''
+
+        # Whole subtree (self + descendants). The non-leaf metrics below aggregate
+        # over every admin level rooted at `adm`, so the card answers "how big is
+        # everything under this region/commune/..." in one place.
+        descendants = adm.get_all_descendants() if children_count else []
+        subtree_ids = [adm.id] + [d.id for d in descendants]
+        total_villages = sum(1 for d in descendants if not d.children.exists())
+        if not children_count:
+            # Leaf entity (typically a village) counts as 1 itself.
+            total_villages = 1
+
+        # Population: prefer the entity's own number when set, otherwise roll up
+        # from descendants (most non-leaf rows store 0 in this dataset).
+        if adm.total_population:
+            total_population = adm.total_population
+        else:
+            total_population = (
+                AdministrativeLevel.objects
+                .filter(id__in=subtree_ids)
+                .aggregate(s=Sum('total_population'))['s'] or 0
+            )
+
+        investments_qs = Investment.objects.filter(administrative_level_id__in=subtree_ids)
+        total_priorities = investments_qs.filter(investment_status=Investment.PRIORITY).count()
+        total_projects_funded = investments_qs.exclude(project_status=Investment.NOT_FUNDED).count()
+
+        breadcrumb = []
+        cur = adm.parent
+        while cur is not None:
+            breadcrumb.insert(0, cur)
+            cur = cur.parent
+
+        ctx = {
+            'adm': adm,
+            'type_label': (adm.type or '').strip().capitalize(),
+            'detail_url': detail_url,
+            'children_count': children_count,
+            'next_level_label': next_level_label,
+            'total_villages': total_villages,
+            'total_population': total_population,
+            'has_population': total_population > 0,
+            'total_priorities': total_priorities,
+            'total_projects_funded': total_projects_funded,
+            'has_coordinates': adm.latitude is not None and adm.longitude is not None,
+            'breadcrumb': breadcrumb,
+        }
+        html = render_to_string(
+            'administrative_level/partials/summary_card.html', ctx, request=request
+        )
+        return HttpResponse(html)
 
 
 class TaskDetailAjaxView(generic.TemplateView):

--- a/cosomis/administrativelevels/views.py
+++ b/cosomis/administrativelevels/views.py
@@ -62,19 +62,16 @@ class AdministrativeLevelsListView(PageMixin, LoginRequiredApproveRequiredMixin,
         search = self.request.GET.get("search", None)
         page_number = self.request.GET.get("page", None)
         _type = self.request.GET.get("type", "Village")
+        # `type` is stored in different casings across datasets (e.g. "Village"
+        # in the Togo seed vs "village" in the Benin dump), so always compare
+        # case-insensitively. Ordered by name so pagination is deterministic.
+        base = AdministrativeLevel.objects.filter(type__iexact=_type).order_by("name")
         if search:
             if search == "All":
-                ads = AdministrativeLevel.objects.filter(type=_type)
-                return Paginator(ads, ads.count()).get_page(page_number)
+                return Paginator(base, base.count() or 1).get_page(page_number)
             search = search.upper()
-            return Paginator(
-                AdministrativeLevel.objects.filter(type=_type, name__icontains=search),
-                100,
-            ).get_page(page_number)
-        else:
-            return Paginator(
-                AdministrativeLevel.objects.filter(type=_type), 100
-            ).get_page(page_number)
+            return Paginator(base.filter(name__icontains=search), 100).get_page(page_number)
+        return Paginator(base, 100).get_page(page_number)
 
         # return super().get_queryset()
 
@@ -144,26 +141,33 @@ class AdministrativeLevelSearchListView(PageMixin, LoginRequiredApproveRequiredM
         search = self.request.GET.get("search", None)
         page_number = self.request.GET.get("page", None)
         _type = self.request.GET.get("type", "Village")
+        # `type` is stored in different casings across datasets (e.g. "Village"
+        # in the Togo seed vs "village" in the Benin dump), so always compare
+        # case-insensitively. Ordered by name so pagination is deterministic.
+        base = AdministrativeLevel.objects.filter(type__iexact=_type).order_by("name")
         if search:
             if search == "All":
-                ads = AdministrativeLevel.objects.filter(type=_type)
-                return Paginator(ads, ads.count()).get_page(page_number)
+                return Paginator(base, base.count() or 1).get_page(page_number)
             search = search.upper()
-            return Paginator(
-                AdministrativeLevel.objects.filter(type=_type, name__icontains=search),
-                100,
-            ).get_page(page_number)
-        else:
-            return Paginator(
-                AdministrativeLevel.objects.filter(type=_type), 100
-            ).get_page(page_number)
+            return Paginator(base.filter(name__icontains=search), 100).get_page(page_number)
+        return Paginator(base, 100).get_page(page_number)
 
     def get_context_data(self, **kwargs):
         ctx = super(AdministrativeLevelSearchListView, self).get_context_data(**kwargs)
-        ctx["form"] = VillageSearchForm()
+        # Pull the actual level names from the data so the form labels, select2
+        # placeholders, and the "Choice the X in Y" / "See X" copy can match
+        # the dataset's vocabulary (Country/Département/... for Benin,
+        # Region/Prefecture/... for Togo, etc.).
+        hierarchy_labels = AdministrativeLevel.get_hierarchy_labels()
+        ctx["form"] = VillageSearchForm(hierarchy_labels=hierarchy_labels)
         ctx["search"] = self.request.GET.get("search", None)
         ctx["type"] = self.request.GET.get("type", "Village")
         ctx["current_language"] = translation.get_language()
+        ctx["hierarchy_labels"] = hierarchy_labels
+        ctx["leaf_label"] = hierarchy_labels[-1] if hierarchy_labels else _("Village")
+        ctx["parent_of_leaf_label"] = (
+            hierarchy_labels[-2] if len(hierarchy_labels) >= 2 else _("Canton")
+        )
         return ctx
 
 

--- a/cosomis/investments/templates/investments/list.html
+++ b/cosomis/investments/templates/investments/list.html
@@ -43,6 +43,57 @@
             }
         }
 
+        /* Skeleton shimmer placeholders for the metric cards */
+        .skeleton {
+            display: inline-block;
+            background: linear-gradient(90deg, #e9ecef 25%, #f5f5f5 37%, #e9ecef 63%);
+            background-size: 400% 100%;
+            animation: skeleton-shimmer 1.4s ease infinite;
+            border-radius: 3px;
+            vertical-align: middle;
+        }
+        .skeleton-text {
+            height: 1.1em;
+            width: 90px;
+        }
+        @keyframes skeleton-shimmer {
+            0%   { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+
+        /* Centered overlay shown while the investments table is fetching */
+        .dataTables_wrapper { position: relative; }
+        .table-loading-overlay {
+            position: absolute;
+            inset: 0;
+            background: rgba(255, 255, 255, 0.78);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            flex-direction: column;
+            z-index: 10;
+            border-radius: 4px;
+            transition: opacity .15s ease;
+        }
+        .table-loading-overlay.is-active { display: flex; }
+        .table-loading-overlay .spinner {
+            width: 44px;
+            height: 44px;
+            border: 4px solid #e3e3e3;
+            border-top-color: #3498db;
+            border-radius: 50%;
+            animation: rotation 0.9s linear infinite;
+        }
+        .table-loading-overlay .loading-text {
+            margin-top: 12px;
+            color: #3498db;
+            font-weight: 600;
+            font-size: 14px;
+            letter-spacing: .2px;
+        }
+        /* DataTables' default tiny "Processing..." is replaced by the overlay above */
+        .dataTables_processing { display: none !important; }
+
         /* Style for table links - Make canton and other links clickable and visible */
         table.table tbody tr td a {
             color: #3498db !important;
@@ -631,34 +682,34 @@
                     <div class="row">
                         <div class="col-3">
                             <p class="text-sm">{% translate 'Total villages available' %}:
-                                <b class="d-block total-villages-display">0</b>
+                                <b class="d-block total-villages-display"><span class="skeleton skeleton-text" aria-label="{% translate 'Loading' %}"></span></b>
                             </p>
                         </div>
                         <div class="col-3">
                             <p class="text-sm">{% translate 'Total sub-projects available' %}:
-                                <b class="d-block total-subprojects-display">0</b>
+                                <b class="d-block total-subprojects-display"><span class="skeleton skeleton-text" aria-label="{% translate 'Loading' %}"></span></b>
                             </p>
                         </div>
                         <div class="col-3">
                             <p class="text-sm">{% translate 'Total funding required' %}:
-                                <b class="d-block total-funding-display">0 FCFA</b>
+                                <b class="d-block total-funding-display"><span class="skeleton skeleton-text" style="width:140px" aria-label="{% translate 'Loading' %}"></span></b>
                             </p>
                         </div>
                     </div>
                     <div class="row">
                         <div class="col-3">
-                            <p class="text-sm">{% translate '# Villages selected' %}: <span class="d-none loader"></span>
-                                <b class="d-block total-selected-villages-display">0</b>
+                            <p class="text-sm">{% translate '# Villages selected' %}:
+                                <b class="d-block total-selected-villages-display"><span class="skeleton skeleton-text" aria-label="{% translate 'Loading' %}"></span></b>
                             </p>
                         </div>
                         <div class="col-3">
-                            <p class="text-sm">{% translate '# Sub-projects selected' %}: <span class="d-none loader"></span>
-                                <b class="d-block total-selected-subprojects-display">0</b>
+                            <p class="text-sm">{% translate '# Sub-projects selected' %}:
+                                <b class="d-block total-selected-subprojects-display"><span class="skeleton skeleton-text" aria-label="{% translate 'Loading' %}"></span></b>
                             </p>
                         </div>
                         <div class="col-3">
-                            <p class="text-sm">{% translate 'Total funding selected' %}: <span class="d-none loader"></span>
-                                <b class="d-block total-selected-funding-display">0 FCFA</b>
+                            <p class="text-sm">{% translate 'Total funding selected' %}:
+                                <b class="d-block total-selected-funding-display"><span class="skeleton skeleton-text" style="width:140px" aria-label="{% translate 'Loading' %}"></span></b>
                             </p>
                         </div>
                     </div>
@@ -668,6 +719,10 @@
                     {% if investments.count == 0 %}
                         {% translate 'You have no investments' %}
                     {% else %}
+                        <div class="table-loading-overlay is-active" id="investments-table-overlay" role="status" aria-live="polite">
+                            <div class="spinner" aria-hidden="true"></div>
+                            <div class="loading-text">{% translate 'Loading investments…' %}</div>
+                        </div>
                         <table class="table table-bordered table-striped" style="width: 100%;">
                             <thead>
                                 <th data-priority="1" class="align-middle"><input class="" id="checkbox-select-all" type="checkbox"></th>
@@ -772,6 +827,11 @@
     let investments_list = [];
     let table = $(".table").DataTable({{ datatable_config | safe }});
 
+    // Toggle the centered overlay whenever DataTables fetches or processes rows.
+    table.on('processing.dt', function (e, settings, processing) {
+        $('#investments-table-overlay').toggleClass('is-active', !!processing);
+    });
+
     let urlObj = new URL(table.ajax.url());
     let params = new URLSearchParams(urlObj.search);
     params.set('project_id', $('#project-select-id').val());
@@ -783,9 +843,18 @@
         $('[data-toggle="popover"]').popover();
     });
 
+    const SKELETON_NUM = '<span class="skeleton skeleton-text" aria-label="Loading"></span>';
+    const SKELETON_MONEY = '<span class="skeleton skeleton-text" style="width:140px" aria-label="Loading"></span>';
+
+    function paint_skeletons(selectors_with_money) {
+        // selectors_with_money: array of [selector, isMoney]
+        selectors_with_money.forEach(function (pair) {
+            $(pair[0]).html(pair[1] ? SKELETON_MONEY : SKELETON_NUM);
+        });
+    }
+
     function sum_subprojects() {
         let base_url = window.location.href.split('?')[0]
-        let loader = $('.loader');
 
         $.ajax({
             type: "POST",
@@ -797,23 +866,26 @@
                 csrfmiddlewaretoken: '{{ csrf_token }}',
             },
             beforeSend: function() {
-                loader.removeClass('d-none');
-                loader.addClass('d-inline-block');
+                paint_skeletons([
+                    ['.total-selected-villages-display', false],
+                    ['.total-selected-subprojects-display', false],
+                    ['.total-selected-funding-display', true],
+                ]);
             },
             success: function(response) {
                 $('.total-selected-funding-display').html(numeral(response.total_funding_display).format('0,0') + ' FCFA');
                 $('.total-selected-villages-display').html(numeral(response.total_villages_display).format('0,0'));
                 $('.total-selected-subprojects-display').html(numeral(response.total_subprojects_display).format('0,0'));
-
-                loader.removeClass('d-inline-block');
-                loader.addClass('d-none');
+            },
+            error: function() {
+                $('.total-selected-villages-display, .total-selected-subprojects-display').text('—');
+                $('.total-selected-funding-display').text('—');
             }
         })
     }
 
     function init_total_values() {
         let base_url = window.location.href.split('?')[0]
-        let loader = $('.loader');
 
         $.ajax({
             type: "POST",
@@ -825,16 +897,20 @@
                 csrfmiddlewaretoken: '{{ csrf_token }}',
             },
             beforeSend: function() {
-                loader.removeClass('d-none');
-                loader.addClass('d-inline-block');
+                paint_skeletons([
+                    ['.total-villages-display', false],
+                    ['.total-subprojects-display', false],
+                    ['.total-funding-display', true],
+                ]);
             },
             success: function(response) {
                 $('.total-funding-display').html(numeral(response.total_funding_display).format('0,0') + ' FCFA');
                 $('.total-villages-display').html(numeral(response.total_villages_display).format('0,0'));
                 $('.total-subprojects-display').html(numeral(response.total_subprojects_display).format('0,0'));
-
-                loader.removeClass('d-inline-block');
-                loader.addClass('d-none');
+            },
+            error: function() {
+                $('.total-villages-display, .total-subprojects-display').text('—');
+                $('.total-funding-display').text('—');
             }
         })
     }


### PR DESCRIPTION
## Summary

Three loosely-related improvements bundled together because they share the
same root cause (and a couple of helpers):

- **Admin-levels search page revamp** — sticky summary card on the right that
  updates as you drill `region → … → village`. Shows name, type badge,
  ancestor breadcrumb, direct-child count using the dataset's own
  vocabulary (e.g. "10 Arrondissements" on Benin, "10 Cantons" on Togo),
  total descendant villages, total population rolled up across the subtree,
  **total priorities** (`investment_status = PRIORITY`), **projects funded**
  (`project_status != NOT_FUNDED`), and an "Open *<type>* profile" CTA. New
  endpoint `administrativelevels:utils:administrative_level_summary` renders
  a server-side HTML fragment.
- **Dataset-agnostic admin-level handling** — `adm_breadcrumb`,
  `VillageSearchForm`, and `AdministrativeLevel*ListView.get_queryset()` no
  longer hard-code `Region/Prefecture/Commune/Canton/Village`. They go
  through the new `AdministrativeLevel.get_hierarchy_labels()` helper and
  position-in-hierarchy routing instead. The Benin dump (`country` /
  `département` / `commune` / `arrondissement` / `village`) now renders
  correctly across the search form, breadcrumbs, select2 placeholders, and
  the "Choice the *<leaf>* in *<parent>*" / "Open *<type>* profile" copy.
- **Investments index loading UX** — skeleton-shimmer placeholders on the
  six metric cards instead of static `0` / `0 FCFA`, plus a centred 44 px
  overlay spinner on the DataTable (replaces DataTables' tiny corner
  "Processing…" badge), wired to the `processing.dt` event.

Also adds the supporting docs: refreshed [`cosomis/README.md`](cosomis/README.md)
with the Docker-Postgres + dump-restore quickstart, a
[`cosomis/CHANGELOG.md`](cosomis/CHANGELOG.md) entry, and a
[`cosomis/CLAUDE.md`](cosomis/CLAUDE.md) capturing the type-string pitfall and
project conventions so we stop hitting the same bug.

## Test plan

- [ ] Search page (`/en/administrative-levels/search/`)
  - Region dropdown is populated (was empty on Benin)
  - Selecting any level updates the summary card on the right with the right
    metrics and CTA
  - Top-right search box returns villages by name
- [ ] Village detail (`/en/administrative-levels/village/694/`) — breadcrumb
  shows four clickable ancestors (BENIN / ATACORA / NATITINGOU / TCHOUMI-TCHOUMI)
- [ ] Investments page (`/en/investments/`) — skeleton bars appear on the six
  totals cards on first load and during AJAX refreshes; centred overlay
  appears while the DataTable fetches
- [ ] Smoke-test on the Togo seed (if you have one handy) to confirm labels
  read `Region / Prefecture / Commune / Canton`

## Out of scope

`administrativelevels/services/canton_summary_service.py` still asserts
`canton.type == AdministrativeLevel.CANTON`, which 500s the `/canton/<id>/`,
`/commune/<id>/`, and `/prefecture/<id>/` pages on non-Togo datasets. That's
tracked separately and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)