### PR TITLE
fix(administrativelevels): map Benin 'country' root to canonical REGION

### DIFF
--- a/cosomis/administrativelevels/models.py
+++ b/cosomis/administrativelevels/models.py
@@ -48,16 +48,17 @@ class AdministrativeLevel(BaseModel):
     )
 
     # Different country datasets store the same logical level under different
-    # type strings — e.g. the Benin dataset uses 'arrondissement' for Canton
-    # and 'département' for Prefecture. All comparisons against `type` go
-    # through aliases_for() / type_filter_q() / is_*() so call sites never
-    # hard-code a single spelling.
+    # type strings — e.g. the Benin dataset uses 'arrondissement' for Canton,
+    # 'département' for Prefecture, and 'country' for the root that Togo
+    # labels 'Region'. All comparisons against `type` go through
+    # aliases_for() / type_filter_q() / is_*() so call sites never hard-code
+    # a single spelling.
     TYPE_ALIASES = {
         VILLAGE: ('village',),
         CANTON: ('canton', 'arrondissement'),
         COMMUNE: ('commune',),
         PREFECTURE: ('prefecture', 'département', 'departement'),
-        REGION: ('region', 'région'),
+        REGION: ('region', 'région', 'country'),
     }
 
     # system properties


### PR DESCRIPTION
## Summary

- Add `'country'` to the `REGION` tuple in `AdministrativeLevel.TYPE_ALIASES` ([cosomis/administrativelevels/models.py:60](https://github.com/e3tools/local-development-portal/blob/claude/region-alias-country/cosomis/administrativelevels/models.py#L60)) so the Benin dataset's root (`type='country'`) is recognized by every alias-aware helper (`type_filter_q`, `aliases_for`, `matches_type`, `is_region`).
- Update the explanatory comment above `TYPE_ALIASES` to mention the Benin root mapping alongside the existing Canton/Prefecture examples.

## Why

CLAUDE.md already documents that Benin's root level (`type='country'`) maps to the canonical `REGION` level — but the alias map didn't reflect that, so any alias-aware caller returned zero matches on Benin. Concretely, the cart's region-filter parent-chain query in `InvestmentModelViewSet.get_queryset` (`cosomis/investments/ajax_views.py`) returned 0 rows for the BENIN root even though 2,733 priority investments roll up to it.

This change is independently correct and intentionally **not bundled** with the parallel `claude/fix-investment-cart-type-aliases` branch, which switches that cart filter from the literal `type=AdministrativeLevel.REGION` to `type_filter_q(REGION, field=…)`. Once both land, the cart's region filter will reach Benin priorities end-to-end.

## Impact audit

Searched all REGION usages across the project:

- The only develop2 caller using the alias helper is `is_region()` — which will now return `True` for the Benin root. That matches CLAUDE.md's documented intent ("Root (0) | `Region` | `country`").
- All other REGION references are bare literals (`type=AdministrativeLevel.REGION`, `adm_obj.type == AdministrativeLevel.REGION`). Literal equality is unaffected by alias-map changes, so no existing query is silently widened.
- Other alias tuples (`VILLAGE`, `CANTON`, `COMMUNE`, `PREFECTURE`) are unchanged.

## Test plan

- [x] Unit-level: `AdministrativeLevel.aliases_for(REGION)` → `('region', 'région', 'country')`; `matches_type` returns True for `country`/`Country`/`Region`/`région` and False for `village`.
- [x] ORM-level on local Benin DB (root: `BENIN`, id=953, type=`country`):
  - `AdministrativeLevel.objects.filter(type_filter_q(REGION)).count()` → **1** (was 0).
  - Simulating the cart's parent-chain region-filter query (`Investment.objects.filter(type_filter_q(REGION, field='administrative_level__parent__parent__parent__parent__type'), administrative_level__parent__parent__parent__parent__id=953).count()`) → **2733** (was 0 with the literal pattern).
- [ ] End-to-end HTTP verification (`GET /en/investments/ajax/datatable/?region-filter=<root-id>` returns rows on Benin) requires the parallel cart-fix branch to land first; tracked on `claude/fix-investment-cart-type-aliases`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)