### PR TITLE
fix(investments): alias-aware type filter in cart hierarchy queryset

### DIFF
--- a/cosomis/investments/ajax_views.py
+++ b/cosomis/investments/ajax_views.py
@@ -131,42 +131,57 @@ class InvestmentModelViewSet(ModelViewSet):
             "region-filter"
         ] not in ["", None]:
             queryset = queryset.filter(
+                AdministrativeLevel.type_filter_q(
+                    AdministrativeLevel.REGION,
+                    field="administrative_level__parent__parent__parent__parent__type",
+                ),
                 administrative_level__parent__parent__parent__parent__id=self.request.GET[
                     "region-filter"
                 ],
-                administrative_level__parent__parent__parent__parent__type=AdministrativeLevel.REGION,
             )
         if "prefecture-filter" in self.request.GET and self.request.GET[
             "prefecture-filter"
         ] not in ["", None]:
             queryset = queryset.filter(
+                AdministrativeLevel.type_filter_q(
+                    AdministrativeLevel.PREFECTURE,
+                    field="administrative_level__parent__parent__parent__type",
+                ),
                 administrative_level__parent__parent__parent__id=self.request.GET[
                     "prefecture-filter"
                 ],
-                administrative_level__parent__parent__parent__type=AdministrativeLevel.PREFECTURE,
             )
         if "commune-filter" in self.request.GET and self.request.GET[
             "commune-filter"
         ] not in ["", None]:
             queryset = queryset.filter(
+                AdministrativeLevel.type_filter_q(
+                    AdministrativeLevel.COMMUNE,
+                    field="administrative_level__parent__parent__type",
+                ),
                 administrative_level__parent__parent__id=self.request.GET[
                     "commune-filter"
                 ],
-                administrative_level__parent__parent__type=AdministrativeLevel.COMMUNE,
             )
         if "canton-filter" in self.request.GET and self.request.GET[
             "canton-filter"
         ] not in ["", None]:
             queryset = queryset.filter(
+                AdministrativeLevel.type_filter_q(
+                    AdministrativeLevel.CANTON,
+                    field="administrative_level__parent__type",
+                ),
                 administrative_level__parent__id=self.request.GET["canton-filter"],
-                administrative_level__parent__type=AdministrativeLevel.CANTON,
             )
         if "village-filter" in self.request.GET and self.request.GET[
             "village-filter"
         ] not in ["", None]:
             queryset = queryset.filter(
+                AdministrativeLevel.type_filter_q(
+                    AdministrativeLevel.VILLAGE,
+                    field="administrative_level__type",
+                ),
                 administrative_level__id=self.request.GET["village-filter"],
-                administrative_level__type=AdministrativeLevel.VILLAGE,
             )
 
         if "sector-filter" in self.request.GET and self.request.GET[


### PR DESCRIPTION
## Summary
- `InvestmentModelViewSet.get_queryset` in [investments/ajax_views.py](cosomis/investments/ajax_views.py) hard-coded the Togo canonical type strings (`REGION`/`PREFECTURE`/`COMMUNE`/`CANTON`/`VILLAGE`) on the parent-chain filters, so the cart's region/prefecture/commune/canton/village filters matched **zero rows on the Benin dataset** (which stores `'country'`, `'département'`, `'commune'`, `'arrondissement'`, `'village'`).
- Replaces each `__type=AdministrativeLevel.<X>` literal with the dataset-agnostic `AdministrativeLevel.type_filter_q(<X>, field=...)` Q expression that matches every alias (case-insensitive) — same helper introduced in [5eb4cd42](https://github.com/e3tools/local-development-portal/commit/5eb4cd42) and used by `administrativelevels/views.py`, `canton_summary_service.py`, etc.
- Togo behavior is preserved: the canonical strings (`'Prefecture'`, `'Village'`, …) remain valid aliases via the helper's `__iexact` match.

## Verification
Ran against the local Benin DB (`country` / `département` / `commune` / `arrondissement` / `village`):

| Filter | OLD (`__type=` literal) | NEW (`type_filter_q`) |
| --- | --- | --- |
| `prefecture-filter=507` (ALIBORI) | **0** | **339** |
| `commune-filter=508` | **0** | **45** |
| `region-filter=953` (BENIN root) | 0 | 0 ⚠️ (see follow-up) |

HTTP end-to-end via `/en/investments/ajax/datatable/?…` returns the same counts.

## Known follow-up (out of scope here)
The region filter still returns 0 on Benin because `AdministrativeLevel.TYPE_ALIASES[REGION]` is `('region', 'région')` and the Benin root is stored as `'country'`. That's a one-line edit to the alias map in [administrativelevels/models.py:55-61](cosomis/administrativelevels/models.py:55), kept out of this PR to honor the "don't bundle" scope.

## Test plan
- [ ] On Togo dataset: confirm cart hierarchy filters still narrow as expected (no regression — canonical types `'Region'`, `'Prefecture'`, etc. continue to match via `iexact`).
- [ ] On Benin dataset: open `/investments/cart` and verify the prefecture / commune / canton / village dropdowns each return >0 investments when a value is picked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)