### PR TITLE
feat(attachments): add download button + village link to lightbox

### DIFF
--- a/cosomis/administrativelevels/templates/attachments/_grid.html
+++ b/cosomis/administrativelevels/templates/attachments/_grid.html
@@ -12,6 +12,7 @@
                      data-attachment-id="{{ attachment.id }}"
                      data-count="{{ forloop.counter0 }}"
                      data-url="{{ attachment.url|imgAWSS3Filter }}"
+                     data-download-url="{% url 'administrativelevels:attachment_download_by_id' attachment.id %}"
                      data-type="{{ attachment.type }}"
                      {% if attachment.adm %}
                      data-adm-url="{% url 'administrativelevels:village_detail' attachment.adm.id %}"

--- a/cosomis/administrativelevels/templates/attachments/attachments.html
+++ b/cosomis/administrativelevels/templates/attachments/attachments.html
@@ -215,12 +215,30 @@
         }
 
         #attachmentModal .modal-dialog {
-            max-width: 900px;
+            max-width: 1100px;
+        }
+
+        #attachmentModal .modal-content {
+            border-radius: 12px;
+            overflow: hidden;
+        }
+
+        #attachmentModal .modal-body {
+            padding: 16px 20px 20px;
         }
 
         #attachmentModal .carousel-item img {
-            max-height: 70vh;
+            max-height: 62vh;
+            max-width: 100%;
             width: auto;
+            object-fit: contain;
+            border-radius: 4px;
+        }
+
+        #attachmentModal .carousel-control-prev,
+        #attachmentModal .carousel-control-next {
+            width: 48px;
+            opacity: 0.85;
         }
 
         #attachmentModal .carousel-control-next-icon,
@@ -233,8 +251,8 @@
             width: 30px;
         }
 
-        #attachmentModal .carousel-indicators li {
-            background-color: #599cf7;
+        #attachmentModal .carousel-indicators {
+            display: none;
         }
 
         #attachmentModal .lightbox-header {
@@ -278,7 +296,9 @@
             display: flex;
             justify-content: center;
             align-items: center;
-            margin-top: 14px;
+            margin-top: 16px;
+            padding-top: 14px;
+            border-top: 1px solid #eef1f4;
             flex-wrap: wrap;
             gap: 8px;
         }
@@ -288,6 +308,10 @@
             display: flex;
             align-items: center;
             justify-content: center;
+            background: #0e1217;
+            border-radius: 8px;
+            padding: 12px;
+            margin: 0 36px;
         }
 
         #attachmentModal .lightbox-doc {
@@ -526,7 +550,7 @@
         $(document).ready(function () {
 
             let current_page = "{{ request.path }}";
-            let query_string = {{ filter_hierarchy_query_strings|safe }};
+            let query_string = {{ filter_hierarchy_query_strings|default_if_none:"{}"|safe }};
             const filter_inputs = [$('#id_region'), $('#id_prefecture'), $('#id_commune'), $('#id_canton'),
                 $('#id_village')];
 
@@ -629,6 +653,7 @@
 
             const lightboxStrings = {
                 openInNewTab: "{% translate 'Open in new tab' %}",
+                download: "{% translate 'Download' %}",
                 previous: "{% translate 'Previous' %}",
                 next: "{% translate 'Next' %}",
                 openDocument: "{% translate 'Open document' %}",
@@ -691,14 +716,22 @@
 
             function buildSlideFooter(card) {
                 const url = escapeHtml(card.dataset.url || '');
+                const downloadUrl = escapeHtml(card.dataset.downloadUrl || '');
                 const admUrl = card.dataset.admUrl;
+                const admLabel = card.dataset.admLabel || '';
                 let html = '<div class="lightbox-footer">';
-                html += '<a href="' + url + '" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary">' +
+                if (downloadUrl) {
+                    html += '<a href="' + downloadUrl + '" class="btn btn-sm btn-primary">' +
+                        '<i class="fas fa-download"></i> ' + escapeHtml(lightboxStrings.download) +
+                        '</a>';
+                }
+                html += '<a href="' + url + '" target="_blank" rel="noopener" class="btn btn-sm btn-outline-primary ml-2">' +
                     '<i class="fas fa-external-link-alt"></i> ' + escapeHtml(lightboxStrings.openInNewTab) +
                     '</a>';
                 if (admUrl) {
+                    const label = admLabel || lightboxStrings.viewLocation;
                     html += '<a href="' + escapeHtml(admUrl) + '" class="btn btn-sm btn-outline-secondary ml-2">' +
-                        '<i class="fas fa-map-marker-alt"></i> ' + escapeHtml(lightboxStrings.viewLocation) +
+                        '<i class="fas fa-map-marker-alt"></i> ' + escapeHtml(label) +
                         '</a>';
                 }
                 html += '</div>';

--- a/cosomis/administrativelevels/urls.py
+++ b/cosomis/administrativelevels/urls.py
@@ -14,6 +14,8 @@ urlpatterns = [
          name='attachment_download'),
     path('detail/<int:adm_id>/attachments/download-zip/', views.attachment_download_zip,
          name='attachment_download_zip'),
+    path('attachments/<int:pk>/download/', views.attachment_download_by_id,
+         name='attachment_download_by_id'),
 
     path('village/<int:pk>/', views.AdministrativeLevelDetailView.as_view(), name='village_detail'),
     path('canton/<int:pk>/', views.CantonDetailView.as_view(), name='canton_detail'),

--- a/cosomis/administrativelevels/views.py
+++ b/cosomis/administrativelevels/views.py
@@ -1651,6 +1651,31 @@ def attachment_download(self, adm_id: int, url: str):
 
 
 @login_required
+def attachment_download_by_id(request, pk: int):
+    attachment = Attachment.objects.get(pk=pk)
+    url = attachment.url.split("?")[0]
+    response = requests.get(url)
+    if response.status_code != 200:
+        return HttpResponse("Failed to download the file.", status=502)
+
+    filename = url.split("/")[-1]
+    content_disposition = response.headers.get("content-disposition")
+    if content_disposition is not None:
+        try:
+            fname = re.findall('filename="(.+)"', content_disposition)
+            if len(fname) != 0:
+                filename = fname[0]
+        except:
+            pass
+
+    out = HttpResponse(
+        response.content, content_type=response.headers.get("content-type")
+    )
+    out["Content-Disposition"] = f'attachment; filename="{filename}"'
+    return out
+
+
+@login_required
 def attachment_download_zip(self, adm_id: int):
     ids = self.GET.get("ids").split(",")
 


### PR DESCRIPTION
## Summary

- New per-attachment Download button in the gallery lightbox, backed by a server-side endpoint that streams the file with `Content-Disposition: attachment` (cross-origin S3 URLs ignore the HTML `download` attribute, so the existing "Open in new tab" link can't force a download).
- The footer's location pill now shows the actual admin-level label (e.g. `village: WIMMOU`) so it reads as a real link to the village rather than a generic "View location".
- Lightbox layout polish: hide carousel indicators (with 36 slides per page they overlapped the action row), widen modal to 1100px, dark inset behind the photo with side gutters so the carousel arrows stop overlapping the image, and a top-bordered footer.
- Fixes a pre-existing JS bug exposed when no admin-level filter is set: `filter_hierarchy_query_strings` was rendering as the bare literal `None` and throwing `ReferenceError: None is not defined`, which broke `$(document).ready()` and prevented the lightbox from opening.

## Why

The attachments gallery redesign that just landed in #89 added a lightbox carousel, but the footer's "Open in new tab" link doesn't trigger a real download for the S3-hosted files (cross-origin), and the "View location" label was a generic placeholder. Users asked for an explicit Download button and a clearer village link. The `None` leak only fired on the unfiltered view, so it wasn't caught at merge time.

## Changes

- `administrativelevels/views.py` — new `attachment_download_by_id(request, pk)` view, mirrors the S3-fetch pattern of `attachment_download_zip` but for a single attachment.
- `administrativelevels/urls.py` — `attachments//download/` route, name `attachment_download_by_id`.
- `administrativelevels/templates/attachments/_grid.html` — each gallery card carries `data-download-url`.
- `administrativelevels/templates/attachments/attachments.html`:
  - `buildSlideFooter` renders the new Download button and uses the admin label as the village-link text.
  - CSS: wider dialog, hidden indicators, image inset with side gutters, footer separator.
  - One-line template fix: `filter_hierarchy_query_strings|default_if_none:"{}"` so the JS literal is always a valid object.

## Test plan

- [x] `/en/administrative-levels/attachments/?type=Photo` opens without JS errors (regression check for the `None` leak — confirm in DevTools console).
- [x] Click any thumbnail → lightbox opens, header shows the village/admin-level link, footer has **Download / Open in new tab / village: ...** in that order.
- [x] Download button writes the file to disk (verified locally against an S3-backed attachment — JPEG bytes streamed with `Content-Disposition: attachment`).
- [x] Village link in the footer navigates to `/en/administrative-levels/village//`.
- [x] Carousel arrows no longer overlap the photo; carousel indicators are hidden; footer sits below a separator.
- [x] Works on both `Photo` and `Document` filters (Document slides fall back to the file-icon panel with the same footer actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)