### PR TITLE
style(dashboard): modernize dashboard-summary charts

### DIFF
--- a/cosomis/dashboard/templates/dashboard_summary.html
+++ b/cosomis/dashboard/templates/dashboard_summary.html
@@ -6,12 +6,26 @@
     <link href="{% static 'plugins/mapbox-gl-js/v2.6.1/mapbox-gl.css' %}" rel="stylesheet">
     <style>
         .card { margin-bottom: 10px; border: 1px solid #e5e7eb; border-radius: 10px; box-shadow: 0 1px 2px rgba(0,0,0,0.03); }
-        .pie-chart { max-width: 260px; max-height: 260px; width: 100%; height: auto; }
+        .pie-chart { max-width: 280px; max-height: 280px; width: 100%; height: auto; }
         .flex-container { display: flex; justify-content: space-between; align-items: center; }
-        .legend { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 4px 12px; list-style: none; padding: 0; margin: 0; font-size: 12.5px; }
-        .legend-item { display: flex; align-items: center; margin-bottom: 0; cursor: pointer; line-height: 1.3; }
-        .legend-item span:last-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-        .legend-color { display: inline-block; width: 10px; height: 10px; margin-right: 6px; flex-shrink: 0; border-radius: 2px; }
+        .legend { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px 10px; list-style: none; padding: 0; margin: 8px 0 0; font-size: 12.5px; }
+        .legend-item {
+            display: flex; align-items: center; gap: 8px;
+            padding: 6px 12px;
+            background: #f9fafb;
+            border: 1px solid #f3f4f6;
+            border-radius: 999px;
+            cursor: pointer;
+            transition: background .15s ease, border-color .15s ease, transform .15s ease;
+            margin: 0;
+            line-height: 1.2;
+        }
+        .legend-item:hover { background: #f3f4f6; border-color: #e5e7eb; transform: translateY(-1px); }
+        .legend-item.is-muted { opacity: 0.45; }
+        .legend-color { display: inline-block; width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; box-shadow: 0 0 0 2px rgba(255,255,255,0.65); }
+        .legend-label { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #374151; font-weight: 500; }
+        .legend-value { color: #111827; font-weight: 700; display: inline-flex; align-items: baseline; gap: 4px; flex-shrink: 0; }
+        .legend-pct { color: #6b7280; font-weight: 500; font-size: 11px; }
         .card-title-container { display: flex; flex-direction: column; justify-content: flex-start; align-items: flex-start; width: 100%; }
         .card-body-horizontal { display: flex; align-items: center; justify-content: space-between; }
         .form-group { margin-bottom: 5px; }
@@ -464,7 +478,7 @@
             subprojects.forEach((subproject, index) => {
                 if ((filterSector === null || subproject.sector__category__name === filterSector) &&
                     subproject.latitude && subproject.longitude) {
-                    const sectorColor = sectorColors[subproject.sector__category__name] || getRandomColor();
+                    const sectorColor = getRandomColor(subproject.sector__category__name);
                     // const markerElement = createCustomMarker(sectorColor);
 
                     let carousel_images_html = ""
@@ -543,14 +557,92 @@
             };
         }
 
-        function getRandomColor() {
-            const letters = '0123456789ABCDEF';
-            let color = '#';
-            for (let i = 0; i < 6; i++) {
-                color += letters[Math.floor(Math.random() * 16)];
+        const CHART_PALETTE = [
+            '#4f46e5', '#10b981', '#f59e0b', '#ef4444', '#06b6d4',
+            '#8b5cf6', '#ec4899', '#84cc16', '#3b82f6', '#14b8a6',
+            '#f97316', '#a855f7', '#22c55e', '#0ea5e9', '#d946ef'
+        ];
+
+        function hashString(s) {
+            let h = 0;
+            const str = String(s || '');
+            for (let i = 0; i < str.length; i++) {
+                h = ((h << 5) - h + str.charCodeAt(i)) | 0;
             }
+            return Math.abs(h);
+        }
+
+        function getRandomColor(label) {
+            if (label && sectorColors[label]) return sectorColors[label];
+            const key = label != null ? String(label) : Math.random().toString(36);
+            const color = CHART_PALETTE[hashString(key) % CHART_PALETTE.length];
+            if (label) sectorColors[label] = color;
             return color;
         }
+
+        if (typeof Chart !== 'undefined' && !Chart._doughnutCenterRegistered) {
+            Chart.register({
+                id: 'doughnutCenterTotal',
+                beforeDraw(chart) {
+                    if (chart.config.type !== 'doughnut') return;
+                    const ds = chart.data && chart.data.datasets && chart.data.datasets[0];
+                    if (!ds) return;
+                    const total = (ds.data || []).reduce((a, b) => a + (Number(b) || 0), 0);
+                    if (!total) return;
+                    const { ctx, chartArea } = chart;
+                    if (!chartArea) return;
+                    const cx = (chartArea.left + chartArea.right) / 2;
+                    const cy = (chartArea.top + chartArea.bottom) / 2;
+                    ctx.save();
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'middle';
+                    ctx.fillStyle = '#111827';
+                    ctx.font = '700 22px Inter, system-ui, -apple-system, "Segoe UI", sans-serif';
+                    ctx.fillText(total.toLocaleString(), cx, cy - 8);
+                    ctx.fillStyle = '#6b7280';
+                    ctx.font = '600 10px Inter, system-ui, -apple-system, "Segoe UI", sans-serif';
+                    ctx.fillText('TOTAL', cx, cy + 12);
+                    ctx.restore();
+                }
+            });
+            Chart._doughnutCenterRegistered = true;
+        }
+
+        const DOUGHNUT_OPTIONS = {
+            cutout: '64%',
+            layout: { padding: 6 },
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    backgroundColor: 'rgba(17, 24, 39, 0.95)',
+                    titleColor: '#fff',
+                    bodyColor: '#fff',
+                    padding: 10,
+                    cornerRadius: 6,
+                    titleFont: { size: 12, weight: '600' },
+                    bodyFont: { size: 12 },
+                    boxPadding: 4,
+                    callbacks: {
+                        label: (ctx) => {
+                            const data = ctx.dataset.data || [];
+                            const total = data.reduce((a, b) => a + (Number(b) || 0), 0);
+                            const value = Number(ctx.parsed) || 0;
+                            const pct = total ? ((value / total) * 100).toFixed(1) : '0';
+                            return ` ${ctx.label}: ${value.toLocaleString()} (${pct}%)`;
+                        }
+                    }
+                }
+            },
+            elements: {
+                arc: {
+                    borderColor: '#fff',
+                    borderWidth: 2,
+                    borderRadius: 4,
+                    hoverOffset: 8
+                }
+            },
+            animation: { duration: 600, easing: 'easeOutQuart' }
+        };
 
         $(document).ready(function() {
             let map = null;
@@ -784,9 +876,9 @@
                 const labels = sectorPriorities.map(item => item.sector__category__name);
                 const data = sectorPriorities.map(item => item.total);
 
-                labels.forEach((label, index) => {
+                labels.forEach((label) => {
                     if (!sectorColors[label]) {
-                        sectorColors[label] = getRandomColor();
+                        sectorColors[label] = getRandomColor(label);
                     }
                 });
 
@@ -815,15 +907,9 @@
                     } else {
                         const ctx = document.getElementById('prioritiesChart').getContext('2d');
                         this.prioritiesChart = new Chart(ctx, {
-                            type: 'pie',
+                            type: 'doughnut',
                             data: chartData,
-                            options: {
-                                plugins: {
-                                    legend: {
-                                        display: false
-                                    }
-                                }
-                            }
+                            options: DOUGHNUT_OPTIONS
                         });
                     }
                     createLegend('prioritiesLegend', chartData, this);
@@ -862,15 +948,9 @@
                             chartInfo.chart.update();
                         } else {
                             chartInfo.chart = new Chart(ctx, {
-                                type: 'pie',
+                                type: 'doughnut',
                                 data: chartData,
-                                options: {
-                                    plugins: {
-                                        legend: {
-                                            display: false
-                                        }
-                                    }
-                                }
+                                options: DOUGHNUT_OPTIONS
                             });
                         }
                         createLegend(chartInfo.legendId, chartData, this);
@@ -906,22 +986,29 @@
 
         function createLegend(legendId, data, statisticsComponent) {
             const legend = document.getElementById(legendId);
-            if (legend) {
-                legend.innerHTML = '';
-                data.datasets[0].data.forEach((value, index) => {
-                    const legendItem = document.createElement('li');
-                    legendItem.className = 'legend-item';
-                    legendItem.innerHTML = `
-                        <span class="legend-color" style="background-color: ${data.datasets[0].backgroundColor[index]}"></span>
-                        ${data.labels[index]}: ${value}
-                    `;
-                    legendItem.addEventListener('click', function() {
-                        const selectedSector = data.labels[index];
-                        updateMap(statisticsComponent.map, allSubprojects, selectedSector);
-                    });
-                    legend.appendChild(legendItem);
+            if (!legend) return;
+            legend.innerHTML = '';
+            const values = data.datasets[0].data || [];
+            const colors = data.datasets[0].backgroundColor || [];
+            const labels = data.labels || [];
+            const total = values.reduce((a, b) => a + (Number(b) || 0), 0);
+            values.forEach((value, index) => {
+                const pct = total ? Math.round((Number(value) || 0) / total * 100) : 0;
+                const label = labels[index] || '';
+                const color = colors[index] || '#9ca3af';
+                const li = document.createElement('li');
+                li.className = 'legend-item';
+                li.title = `${label}: ${value} (${pct}%)`;
+                li.innerHTML = `
+                    <span class="legend-color" style="background-color: ${color}"></span>
+                    <span class="legend-label">${label}</span>
+                    <span class="legend-value">${Number(value).toLocaleString()}<span class="legend-pct">${pct}%</span></span>
+                `;
+                li.addEventListener('click', function() {
+                    updateMap(statisticsComponent.map, allSubprojects, label);
                 });
-            }
+                legend.appendChild(li);
+            });
         }
 
         function debounce(func, wait) {


### PR DESCRIPTION
## Summary

Modernizes the five Chart.js pies on `/en/dashboard/dashboard-summary/` (priorities + four minority-group tabs). Still on Chart.js — **no new dependency**, just better defaults and a curated palette.

- **Curated palette** — replaces `getRandomColor()` (random hex) with a 15-color Tailwind-inspired palette. Sectors are mapped to a color via a stable string hash, so the same sector keeps the same color across reloads instead of changing on every render. Map markers share the mapping.
- **Pie → doughnut** with `cutout: '64%'`, 2 px white slice borders, rounded slice edges, `hoverOffset: 8` for hover pop, and `easeOutQuart` load animation.
- **Center total** — registered a custom Chart.js plugin (`doughnutCenterTotal`) that draws the dataset total + "TOTAL" inside the donut hole.
- **Dark, rounded tooltip** showing `Sector: count (X.X%)` instead of just the bare value.
- **Legend redesigned** as pill-shaped chips: rounded color dot, sector name, count, percentage. Hover lift, click-to-filter-map preserved.

## Why

The previous charts used randomized hex colors per render (neon clashing palettes, different colors per reload), default Chart.js pie styling, and a tiny-square legend with no values. This brings the charts in line with the dashboard's Tailwind-inspired typography and stat-card aesthetics that landed in #88/#89.

## Changes

- `dashboard/templates/dashboard_summary.html`:
  - New `CHART_PALETTE` constant + `hashString()` helper.
  - `getRandomColor(label)` now resolves from the palette and caches into the shared `sectorColors` map; call sites updated to pass the label.
  - `DOUGHNUT_OPTIONS` object reused by both `updatePrioritiesChart()` and `updateMinorityCharts()`.
  - `Chart.register({ id: 'doughnutCenterTotal', ... })` plugin.
  - `createLegend()` rewritten to render pill chips with value + percent.
  - CSS for `.legend`, `.legend-item`, `.legend-color`, `.legend-label`, `.legend-value`, `.legend-pct`.

## Test plan

- [x] Open `/en/dashboard/dashboard-summary/` — five donut charts render with consistent palette colors per sector.
- [x] Reload the page — same sector keeps the same color (no random reshuffle).
- [x] Hover a slice — segment pops out, dark tooltip shows `Sector: count (X.X%)`.
- [x] Center of each donut shows the dataset total and "TOTAL" label.
- [x] Legend chips show name + count + percent; clicking a chip still filters the map by sector.
- [x] Empty-state tab (e.g., a minority group with no data) still shows the "no data" message and hides the chart.
- [x] Map markers use the same sector colors as the donuts (visually verify on the priorities tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)