### PR TITLE
feat(cdd-funnel): country-wide interactive funnel + dataset-aware detail pages

### DIFF
--- a/cosomis/cdd_funnel/services.py
+++ b/cosomis/cdd_funnel/services.py
@@ -1,0 +1,390 @@
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional
+
+from django.db.models import Count, Sum, Q
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+
+from administrativelevels.models import AdministrativeLevel, Task
+from investments.models import Investment
+
+
+@dataclass
+class FunnelStage:
+    key: str
+    label: str
+    description: str
+    icon: str
+    color: str
+    count: int = 0
+    pct_of_total: float = 0.0
+    pct_from_previous: float = 0.0
+    polygon_points: str = ""
+    label_y: float = 0.0
+    width_top: float = 0.0
+    width_mid: float = 0.0
+
+
+@dataclass
+class FunnelSummary:
+    stages: List[FunnelStage]
+    phase_status_dist: Dict[str, int]
+    investment_status_dist: Dict[str, int]
+    sector_breakdown: List[dict]
+    total_estimated_cost: int
+    total_funded_cost: int
+    total_completed_cost: int
+    total_investments: int
+    funded_investments: int
+    completed_investments: int
+    generated_at: str
+    funnel_width: int = 720
+    funnel_height: int = 0
+
+
+class CountryCddFunnelService:
+    """Aggregates a country-wide funnel of the CDD process.
+
+    Stages walk a village from "exists in the dataset" through "CDD process
+    engaged", "planning complete", "priorities identified", "funded",
+    "in execution", to "completed infrastructure". A village can be at
+    multiple stages simultaneously; each stage is an independent count of
+    villages that have reached that point.
+    """
+
+    STAGE_DEFS = [
+        (
+            "all_villages",
+            _("All Villages"),
+            _("Total villages in the country dataset"),
+            "home",
+            "#6366f1",
+        ),
+        (
+            "engaged",
+            _("CDD Engaged"),
+            _("Villages where the CDD process has been initiated"),
+            "users",
+            "#4f46e5",
+        ),
+        (
+            "planning_complete",
+            _("Planning Complete"),
+            _("Villages where every planning task is completed"),
+            "clipboard",
+            "#4338ca",
+        ),
+        (
+            "priorities",
+            _("Priorities Identified"),
+            _("Villages with at least one investment priority"),
+            "lightbulb",
+            "#7c3aed",
+        ),
+        (
+            "funded",
+            _("Funded"),
+            _("Villages with at least one funded investment"),
+            "dollar",
+            "#9333ea",
+        ),
+        (
+            "in_execution",
+            _("In Execution"),
+            _("Villages with infrastructure under construction"),
+            "tool",
+            "#db2777",
+        ),
+        (
+            "completed",
+            _("Completed"),
+            _("Villages with completed infrastructure"),
+            "flag",
+            "#10b981",
+        ),
+    ]
+
+    STAGE_HEIGHT = 78
+    FUNNEL_WIDTH = 720
+    MIN_RATIO = 0.10
+
+    def __init__(self):
+        self._village_qs = AdministrativeLevel.objects.filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE)
+        )
+
+    def get_summary(self) -> FunnelSummary:
+        counts = self._compute_stage_counts()
+        stages = self._build_stages(counts)
+        self._assign_polygons(stages)
+
+        phase_dist = self._phase_status_distribution()
+        inv_dist = self._investment_status_distribution()
+        sectors = self._sector_breakdown()
+        cost = self._cost_aggregates()
+        inv_counts = self._investment_counts()
+
+        return FunnelSummary(
+            stages=stages,
+            phase_status_dist=phase_dist,
+            investment_status_dist=inv_dist,
+            sector_breakdown=sectors,
+            total_estimated_cost=cost["estimated"],
+            total_funded_cost=cost["funded"],
+            total_completed_cost=cost["completed"],
+            total_investments=inv_counts["total"],
+            funded_investments=inv_counts["funded"],
+            completed_investments=inv_counts["completed"],
+            generated_at=timezone.now().isoformat(),
+            funnel_width=self.FUNNEL_WIDTH,
+            funnel_height=self.STAGE_HEIGHT * len(stages),
+        )
+
+    def _compute_stage_counts(self) -> Dict[str, int]:
+        total = self._village_qs.count()
+        engaged = self._village_qs.filter(phases__isnull=False).distinct().count()
+        planning_complete = (
+            self._village_qs.filter(phases__activities__tasks__status=Task.COMPLETED)
+            .exclude(
+                phases__activities__tasks__status__in=[
+                    Task.NOT_STARTED,
+                    Task.IN_PROGRESS,
+                    Task.ERROR,
+                ]
+            )
+            .distinct()
+            .count()
+        )
+        priorities = (
+            self._village_qs.filter(investments__isnull=False).distinct().count()
+        )
+        funded = (
+            self._village_qs.filter(
+                investments__project_status__in=[
+                    Investment.FUNDED,
+                    Investment.IN_PROGRESS,
+                    Investment.COMPLETED,
+                ]
+            )
+            .distinct()
+            .count()
+        )
+        in_execution = (
+            self._village_qs.filter(
+                investments__project_status__in=[
+                    Investment.IN_PROGRESS,
+                    Investment.COMPLETED,
+                ]
+            )
+            .distinct()
+            .count()
+        )
+        completed = (
+            self._village_qs.filter(
+                investments__project_status=Investment.COMPLETED
+            )
+            .distinct()
+            .count()
+        )
+        return {
+            "all_villages": total,
+            "engaged": engaged,
+            "planning_complete": planning_complete,
+            "priorities": priorities,
+            "funded": funded,
+            "in_execution": in_execution,
+            "completed": completed,
+        }
+
+    def _build_stages(self, counts: Dict[str, int]) -> List[FunnelStage]:
+        stages: List[FunnelStage] = []
+        total = counts["all_villages"] or 1
+        prev_count: Optional[int] = None
+        for key, label, description, icon, color in self.STAGE_DEFS:
+            count = counts[key]
+            pct_total = (count / total) * 100 if total else 0.0
+            if prev_count is None:
+                pct_prev = 100.0
+            elif prev_count == 0:
+                pct_prev = 0.0
+            else:
+                pct_prev = (count / prev_count) * 100
+            stages.append(
+                FunnelStage(
+                    key=key,
+                    label=str(label),
+                    description=str(description),
+                    icon=icon,
+                    color=color,
+                    count=count,
+                    pct_of_total=round(pct_total, 1),
+                    pct_from_previous=round(pct_prev, 1),
+                )
+            )
+            prev_count = count
+        return stages
+
+    def _assign_polygons(self, stages: List[FunnelStage]) -> None:
+        """Compute trapezoid polygon points for the SVG funnel.
+
+        Funnel shape is forced monotonically non-increasing so each band is
+        no wider than the one above it, even when the underlying counts are
+        not perfectly nested (e.g. a village can have an Investment priority
+        without having every planning task completed). The numeric label
+        always reflects the true stage count.
+        """
+        if not stages:
+            return
+        baseline = stages[0].count or 1
+        width = self.FUNNEL_WIDTH
+        height = self.STAGE_HEIGHT
+
+        display_ratios = []
+        prev_ratio = 1.0
+        for stage in stages:
+            raw = stage.count / baseline if baseline else 0
+            ratio = min(raw, prev_ratio)
+            ratio = max(ratio, self.MIN_RATIO if stage.count > 0 else self.MIN_RATIO * 0.55)
+            display_ratios.append(ratio)
+            prev_ratio = ratio
+
+        for i, stage in enumerate(stages):
+            ratio_top = display_ratios[i]
+            ratio_bot = display_ratios[i + 1] if i + 1 < len(display_ratios) else max(
+                ratio_top * 0.85, self.MIN_RATIO * 0.55
+            )
+            w_top = width * ratio_top
+            w_bot = width * ratio_bot
+            x_tl = (width - w_top) / 2
+            x_tr = x_tl + w_top
+            x_bl = (width - w_bot) / 2
+            x_br = x_bl + w_bot
+            y_t = i * height
+            y_b = y_t + height
+            stage.polygon_points = (
+                f"{x_tl:.1f},{y_t} {x_tr:.1f},{y_t} "
+                f"{x_br:.1f},{y_b} {x_bl:.1f},{y_b}"
+            )
+            stage.label_y = y_t + height / 2
+            stage.width_top = w_top
+            stage.width_mid = (w_top + w_bot) / 2
+
+    def _phase_status_distribution(self) -> Dict[str, int]:
+        rows = Task.objects.values("status").annotate(c=Count("id"))
+        return {r["status"]: r["c"] for r in rows}
+
+    def _investment_status_distribution(self) -> Dict[str, int]:
+        rows = Investment.objects.values("project_status").annotate(c=Count("id"))
+        return {r["project_status"]: r["c"] for r in rows}
+
+    def _sector_breakdown(self) -> List[dict]:
+        rows = (
+            Investment.objects.values("sector__name")
+            .annotate(count=Count("id"), total_cost=Sum("estimated_cost"))
+            .order_by("-count")[:8]
+        )
+        return [
+            {
+                "name": r["sector__name"] or _("Unspecified"),
+                "count": r["count"],
+                "total_cost": r["total_cost"] or 0,
+            }
+            for r in rows
+        ]
+
+    def _cost_aggregates(self) -> Dict[str, int]:
+        estimated = (
+            Investment.objects.aggregate(s=Sum("estimated_cost"))["s"] or 0
+        )
+        funded = (
+            Investment.objects.filter(
+                project_status__in=[
+                    Investment.FUNDED,
+                    Investment.IN_PROGRESS,
+                    Investment.COMPLETED,
+                ]
+            ).aggregate(s=Sum("estimated_cost"))["s"]
+            or 0
+        )
+        completed = (
+            Investment.objects.filter(
+                project_status=Investment.COMPLETED
+            ).aggregate(s=Sum("estimated_cost"))["s"]
+            or 0
+        )
+        return {"estimated": estimated, "funded": funded, "completed": completed}
+
+    def _investment_counts(self) -> Dict[str, int]:
+        total = Investment.objects.count()
+        funded = Investment.objects.filter(
+            project_status__in=[
+                Investment.FUNDED,
+                Investment.IN_PROGRESS,
+                Investment.COMPLETED,
+            ]
+        ).count()
+        completed = Investment.objects.filter(
+            project_status=Investment.COMPLETED
+        ).count()
+        return {"total": total, "funded": funded, "completed": completed}
+
+    def get_villages_at_stage(self, stage_key: str):
+        qs = self._village_qs.select_related("parent")
+        if stage_key == "all_villages":
+            return qs.order_by("name")
+        if stage_key == "engaged":
+            return qs.filter(phases__isnull=False).distinct().order_by("name")
+        if stage_key == "planning_complete":
+            return (
+                qs.filter(phases__activities__tasks__status=Task.COMPLETED)
+                .exclude(
+                    phases__activities__tasks__status__in=[
+                        Task.NOT_STARTED,
+                        Task.IN_PROGRESS,
+                        Task.ERROR,
+                    ]
+                )
+                .distinct()
+                .order_by("name")
+            )
+        if stage_key == "priorities":
+            return (
+                qs.filter(investments__isnull=False).distinct().order_by("name")
+            )
+        if stage_key == "funded":
+            return (
+                qs.filter(
+                    investments__project_status__in=[
+                        Investment.FUNDED,
+                        Investment.IN_PROGRESS,
+                        Investment.COMPLETED,
+                    ]
+                )
+                .distinct()
+                .order_by("name")
+            )
+        if stage_key == "in_execution":
+            return (
+                qs.filter(
+                    investments__project_status__in=[
+                        Investment.IN_PROGRESS,
+                        Investment.COMPLETED,
+                    ]
+                )
+                .distinct()
+                .order_by("name")
+            )
+        if stage_key == "completed":
+            return (
+                qs.filter(investments__project_status=Investment.COMPLETED)
+                .distinct()
+                .order_by("name")
+            )
+        return qs.none()
+
+    @classmethod
+    def stage_label(cls, stage_key: str) -> str:
+        for key, label, *_rest in cls.STAGE_DEFS:
+            if key == stage_key:
+                return str(label)
+        return ""

--- a/cosomis/cdd_funnel/templates/_stage_villages.html
+++ b/cosomis/cdd_funnel/templates/_stage_villages.html
@@ -1,0 +1,69 @@
+{% load i18n humanize %}
+<div class="drilldown-header">
+    <div>
+        <h3 class="panel-title">{{ stage_label }}</h3>
+        <p class="panel-subtitle">
+            {% blocktranslate count counter=total trimmed %}
+                {{ counter }} village currently at this stage
+            {% plural %}
+                {{ counter|intcomma }} villages currently at this stage
+            {% endblocktranslate %}
+        </p>
+    </div>
+</div>
+
+{% if page_obj.object_list %}
+    <div class="village-grid">
+        {% for village in page_obj.object_list %}
+            <a class="village-chip"
+               href="{% url 'administrativelevels:village_detail' village.id %}"
+               title="{{ village.name }}{% if village.parent %} — {{ village.parent.name }}{% endif %}">
+                <span class="village-chip-name">{{ village.name }}</span>
+                {% if village.parent %}<span class="village-chip-parent">{{ village.parent.name }}</span>{% endif %}
+            </a>
+        {% endfor %}
+    </div>
+
+    {% if page_obj.paginator.num_pages > 1 %}
+        <div class="drilldown-pagination">
+            {% if page_obj.has_previous %}
+                <button type="button"
+                        hx-get="{% url 'cdd_funnel:stage_drilldown' stage_key %}?page={{ page_obj.previous_page_number }}"
+                        hx-target="#drilldown" hx-swap="innerHTML"
+                        hx-indicator="#drilldown-indicator"
+                        class="drilldown-page-btn">
+                    &laquo; {% translate 'Previous' %}
+                </button>
+            {% endif %}
+            <span class="drilldown-page-info">
+                {% blocktranslate with current=page_obj.number total=page_obj.paginator.num_pages %}Page {{ current }} of {{ total }}{% endblocktranslate %}
+            </span>
+            {% if page_obj.has_next %}
+                <button type="button"
+                        hx-get="{% url 'cdd_funnel:stage_drilldown' stage_key %}?page={{ page_obj.next_page_number }}"
+                        hx-target="#drilldown" hx-swap="innerHTML"
+                        hx-indicator="#drilldown-indicator"
+                        class="drilldown-page-btn">
+                    {% translate 'Next' %} &raquo;
+                </button>
+            {% endif %}
+        </div>
+    {% endif %}
+{% else %}
+    <div class="drilldown-empty">
+        <p>{% translate 'No villages at this stage yet.' %}</p>
+    </div>
+{% endif %}
+
+<style>
+    .drilldown-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+    .village-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: 10px; }
+    .village-chip { display: flex; flex-direction: column; padding: 12px 14px; background: #ffffff; border: 1px solid #e5e7eb; border-radius: 10px; text-decoration: none; color: #111827; transition: all .12s ease; min-height: 56px; }
+    .village-chip:hover { border-color: #4f46e5; background: #eef2ff; transform: translateY(-1px); box-shadow: 0 4px 12px rgba(79,70,229,0.08); text-decoration: none; color: #111827; }
+    .village-chip-name { font-size: 13px; font-weight: 600; line-height: 1.2; }
+    .village-chip-parent { font-size: 11px; color: #6b7280; margin-top: 3px; }
+    .drilldown-pagination { display: flex; align-items: center; justify-content: center; gap: 12px; margin-top: 18px; padding-top: 16px; border-top: 1px solid #f3f4f6; }
+    .drilldown-page-btn { background: #ffffff; border: 1px solid #d1d5db; border-radius: 8px; padding: 6px 14px; font-size: 12px; font-weight: 600; color: #374151; cursor: pointer; transition: all .12s; }
+    .drilldown-page-btn:hover { border-color: #4f46e5; color: #4f46e5; background: #eef2ff; }
+    .drilldown-page-info { font-size: 12px; color: #6b7280; }
+</style>

--- a/cosomis/cdd_funnel/templates/cdd_funnel.html
+++ b/cosomis/cdd_funnel/templates/cdd_funnel.html
@@ -1,0 +1,505 @@
+{% extends 'layouts/base.html' %}
+{% load static i18n humanize %}
+
+{% block extracss %}
+    {{ block.super }}
+    <style>
+        .cdd-funnel-page { background: linear-gradient(180deg, #f9fafb 0%, #ffffff 70%); padding: 18px 0 40px; }
+        .cdd-funnel-page .container-fluid { max-width: 1480px; }
+
+        /* Hero */
+        .funnel-hero { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 22px; flex-wrap: wrap; }
+        .funnel-hero h1 { font-size: 24px; font-weight: 700; color: #111827; margin: 0 0 4px; letter-spacing: -0.01em; }
+        .funnel-hero p { color: #6b7280; margin: 0; font-size: 13px; max-width: 720px; }
+        .funnel-hero .hero-badge { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; background: #eef2ff; color: #4338ca; border-radius: 999px; font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; margin-bottom: 8px; }
+        .funnel-hero .hero-stamp { font-size: 11px; color: #9ca3af; }
+
+        /* KPI strip */
+        .kpi-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 14px; margin-bottom: 24px; }
+        .kpi-card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 14px; padding: 18px 20px; transition: transform .15s ease, box-shadow .15s ease; position: relative; overflow: hidden; }
+        .kpi-card::before { content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px; background: linear-gradient(90deg, var(--accent, #6366f1), var(--accent2, #4f46e5)); }
+        .kpi-card:hover { transform: translateY(-2px); box-shadow: 0 8px 22px rgba(15, 23, 42, 0.08); }
+        .kpi-label { font-size: 11px; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: .06em; display: flex; align-items: center; gap: 6px; }
+        .kpi-icon { width: 26px; height: 26px; border-radius: 7px; display: inline-flex; align-items: center; justify-content: center; background: #eef2ff; color: #4f46e5; }
+        .kpi-icon svg { width: 14px; height: 14px; }
+        .kpi-value { font-size: 30px; font-weight: 700; color: #111827; line-height: 1.05; margin: 8px 0 2px; }
+        .kpi-sub { font-size: 12px; color: #6b7280; display: flex; align-items: center; gap: 6px; }
+        .kpi-chip { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; background: #ecfdf5; color: #065f46; }
+        .kpi-chip.neutral { background: #f3f4f6; color: #374151; }
+        .kpi-chip.warn { background: #fef3c7; color: #92400e; }
+
+        /* Funnel panel */
+        .panel { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 14px; padding: 22px; margin-bottom: 20px; }
+        .panel-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 18px; flex-wrap: wrap; }
+        .panel-title { font-size: 16px; font-weight: 600; color: #111827; margin: 0; }
+        .panel-subtitle { font-size: 12px; color: #6b7280; margin: 2px 0 0; }
+
+        .funnel-grid { display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 24px; align-items: stretch; }
+        @media (max-width: 992px) { .funnel-grid { grid-template-columns: 1fr; } }
+
+        .funnel-svg-wrap { display: flex; justify-content: center; align-items: center; padding: 8px 0; }
+        .funnel-svg { width: 100%; height: auto; max-width: 760px; }
+        .funnel-stage { cursor: pointer; transition: filter .15s ease, opacity .15s ease; filter: drop-shadow(0 1px 0 rgba(0,0,0,0.06)); }
+        .funnel-stage:hover { filter: brightness(1.06) drop-shadow(0 4px 10px rgba(0,0,0,0.12)); }
+        .funnel-stage polygon { transition: stroke-width .12s ease; stroke: transparent; stroke-width: 0; }
+        .funnel-stage.active polygon { stroke: #111827; stroke-width: 2.5; }
+        .funnel-stage.dim { opacity: 0.55; }
+        .funnel-stage text { stroke: none; paint-order: stroke fill; }
+        .funnel-label { font-size: 12px; font-weight: 600; fill: #ffffff; pointer-events: none; letter-spacing: .01em; }
+        .funnel-count { font-size: 20px; font-weight: 700; fill: #ffffff; pointer-events: none; }
+        .funnel-count-sm { font-size: 14px; font-weight: 700; fill: #ffffff; pointer-events: none; }
+
+        /* Stage list (right column) */
+        .stage-list { display: flex; flex-direction: column; gap: 8px; }
+        .stage-row { display: grid; grid-template-columns: 36px 1fr auto 16px; align-items: center; gap: 10px; padding: 10px 12px; border: 1px solid #e5e7eb; border-radius: 10px; cursor: pointer; background: #ffffff; transition: all .12s ease; }
+        .stage-row:hover { border-color: #c7d2fe; background: #f5f3ff; }
+        .stage-row:hover .stage-chevron { transform: translateX(2px); color: #4f46e5; }
+        .stage-row.active { border-color: #4f46e5; background: #eef2ff; box-shadow: 0 0 0 3px rgba(79,70,229,0.12); }
+        .stage-row.active .stage-chevron { color: #4f46e5; transform: translateX(2px); }
+        .stage-row .stage-dot { width: 28px; height: 28px; border-radius: 8px; display: inline-flex; align-items: center; justify-content: center; color: white; font-size: 12px; font-weight: 700; }
+        .stage-row .stage-name { font-size: 13px; font-weight: 600; color: #111827; line-height: 1.2; }
+        .stage-row .stage-desc { font-size: 11px; color: #6b7280; margin-top: 2px; }
+        .stage-row .stage-metric { text-align: right; }
+        .stage-row .stage-count { font-size: 16px; font-weight: 700; color: #111827; line-height: 1; }
+        .stage-row .stage-conv { font-size: 10.5px; color: #6b7280; margin-top: 4px; display: inline-flex; align-items: center; gap: 4px; }
+        .stage-row .stage-chevron { color: #9ca3af; transition: transform .12s ease, color .12s ease; display: inline-flex; align-items: center; justify-content: center; }
+        .stage-row .stage-chevron svg { width: 14px; height: 14px; }
+        .stage-conv .conv-arrow { font-size: 9px; }
+
+        /* Conversion mini-bar */
+        .conv-bar { height: 4px; background: #f3f4f6; border-radius: 2px; overflow: hidden; margin-top: 6px; grid-column: 2 / span 3; }
+        .conv-bar .conv-fill { height: 100%; border-radius: 2px; transition: width .8s cubic-bezier(.2,.7,.3,1); }
+
+        /* Distribution panels */
+        .dist-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+        .dist-card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 14px; padding: 18px 20px; }
+        .dist-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 10px; }
+        .dist-title { font-size: 14px; font-weight: 600; color: #111827; margin: 0; }
+        .dist-subtitle { font-size: 11px; color: #6b7280; }
+        .dist-canvas-wrap { position: relative; height: 200px; display: flex; align-items: center; justify-content: center; }
+        .dist-canvas-wrap canvas { max-height: 200px; }
+        .dist-legend { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 6px 12px; margin-top: 14px; }
+        .dist-legend-item { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #374151; }
+        .dist-legend-color { width: 10px; height: 10px; border-radius: 3px; flex-shrink: 0; }
+        .dist-legend-count { margin-left: auto; font-weight: 600; color: #111827; }
+        .dist-empty { color: #9ca3af; font-size: 12px; text-align: center; padding: 40px 12px; }
+
+        /* Sector bar chart */
+        .sector-rows { display: flex; flex-direction: column; gap: 10px; }
+        .sector-row { display: grid; grid-template-columns: 160px 1fr auto; gap: 12px; align-items: center; }
+        .sector-name { font-size: 13px; color: #111827; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .sector-bar { background: #f3f4f6; height: 10px; border-radius: 5px; overflow: hidden; }
+        .sector-bar-fill { height: 100%; background: linear-gradient(90deg, #6366f1, #4f46e5); border-radius: 5px; transition: width .8s cubic-bezier(.2,.7,.3,1); }
+        .sector-count { font-size: 12px; font-weight: 600; color: #111827; text-align: right; min-width: 70px; }
+        .sector-cost { font-size: 11px; color: #6b7280; display: block; font-weight: 400; }
+
+        /* Drilldown (inside the funnel panel) */
+        .drilldown-section { margin-top: 20px; padding-top: 18px; border-top: 1px solid #f3f4f6; }
+        .drilldown-section-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+        .drilldown-section-title { font-size: 14px; font-weight: 600; color: #111827; margin: 0; }
+        .drilldown-section-sub { font-size: 12px; color: #6b7280; margin: 2px 0 0; }
+        .drilldown-empty { color: #9ca3af; text-align: center; padding: 28px 12px; font-size: 13px; display: flex; align-items: center; justify-content: center; gap: 6px; }
+        .drilldown-empty .drilldown-empty-icon { width: 48px; height: 48px; opacity: .4; margin-bottom: 10px; }
+        .htmx-indicator { display: none; }
+        .htmx-request .htmx-indicator { display: inline-block; }
+        .htmx-request.cdd-loading { opacity: 0.6; pointer-events: none; }
+
+        .spinner-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; background: #4f46e5; animation: cdd-pulse 1s infinite alternate; }
+        .spinner-dot:nth-child(2) { animation-delay: .15s; }
+        .spinner-dot:nth-child(3) { animation-delay: .3s; }
+        @keyframes cdd-pulse { from { opacity: .3; transform: scale(.8); } to { opacity: 1; transform: scale(1); } }
+
+        /* Funnel animation on load */
+        @keyframes funnel-fade-in {
+            from { opacity: 0; transform: translateY(8px); }
+            to { opacity: 1; transform: translateY(0); }
+        }
+        .funnel-stage { animation: funnel-fade-in .45s cubic-bezier(.2,.7,.3,1) both; }
+    </style>
+{% endblock %}
+
+{% block content %}
+<div class="cdd-funnel-page">
+    <div class="container-fluid">
+
+        <div class="funnel-hero">
+            <div>
+                <span class="hero-badge">
+                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12,6 12,12 16,14"/></svg>
+                    {% translate 'Country-wide snapshot' %}
+                </span>
+                <h1>{% translate 'CDD Process Funnel' %}</h1>
+                <p>{% translate 'How villages progress through the Community-Driven Development pipeline — from initial engagement to delivered infrastructure. Click any stage to drill into the villages.' %}</p>
+            </div>
+            <div class="text-right">
+                <span class="hero-stamp">{% translate 'Updated' %} <span id="hero-updated-at"></span></span>
+            </div>
+        </div>
+
+        <div class="kpi-row">
+            <div class="kpi-card" style="--accent: #6366f1; --accent2: #4f46e5;">
+                <div class="kpi-label">
+                    <span class="kpi-icon" style="background:#eef2ff; color:#4f46e5;">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9.5L12 3l9 6.5"/><path d="M5 10v10h14V10"/></svg>
+                    </span>
+                    {% translate 'Total villages' %}
+                </div>
+                <div class="kpi-value">{{ first_stage.count|default:0|intcomma }}</div>
+                <div class="kpi-sub">{% translate 'Country dataset' %}</div>
+            </div>
+
+            <div class="kpi-card" style="--accent: #4f46e5; --accent2: #4338ca;">
+                <div class="kpi-label">
+                    <span class="kpi-icon" style="background:#e0e7ff; color:#4338ca;">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                    </span>
+                    {% translate 'CDD engaged' %}
+                </div>
+                <div class="kpi-value">{{ engaged_stage.count|default:0|intcomma }}</div>
+                <div class="kpi-sub">
+                    <span class="kpi-chip neutral">{{ engaged_stage.pct_of_total|default:0 }}%</span>
+                    {% translate 'of all villages' %}
+                </div>
+            </div>
+
+            <div class="kpi-card" style="--accent: #7c3aed; --accent2: #9333ea;">
+                <div class="kpi-label">
+                    <span class="kpi-icon" style="background:#f5f3ff; color:#7c3aed;">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg>
+                    </span>
+                    {% translate 'Funded investments' %}
+                </div>
+                <div class="kpi-value">{{ summary.funded_investments|intcomma }}</div>
+                <div class="kpi-sub">
+                    <span class="kpi-chip">{{ summary.total_funded_cost|intcomma }}</span>
+                    {% translate 'estimated cost (funded)' %}
+                </div>
+            </div>
+
+            <div class="kpi-card" style="--accent: #10b981; --accent2: #059669;">
+                <div class="kpi-label">
+                    <span class="kpi-icon" style="background:#d1fae5; color:#059669;">
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                    </span>
+                    {% translate 'Completed' %}
+                </div>
+                <div class="kpi-value">{{ summary.completed_investments|intcomma }}</div>
+                <div class="kpi-sub">
+                    <span class="kpi-chip">{{ summary.total_completed_cost|intcomma }}</span>
+                    {% translate 'delivered cost' %}
+                </div>
+            </div>
+        </div>
+
+        <div class="panel">
+            <div class="panel-head">
+                <div>
+                    <h2 class="panel-title">{% translate 'The CDD Funnel' %}</h2>
+                    <p class="panel-subtitle">{% translate 'Each band is the count of villages that have reached that stage. Width is proportional to the village total. Click to drill down.' %}</p>
+                </div>
+            </div>
+
+            <div class="funnel-grid">
+                <div class="funnel-svg-wrap">
+                    {% if first_stage.count %}
+                    <svg class="funnel-svg" viewBox="0 0 {{ summary.funnel_width }} {{ summary.funnel_height }}" preserveAspectRatio="xMidYMid meet" role="img" aria-label="{% translate 'CDD funnel' %}">
+                        <defs>
+                            {% for stage in stages %}
+                            <linearGradient id="grad-{{ stage.key }}" x1="0" y1="0" x2="0" y2="1">
+                                <stop offset="0%" stop-color="{{ stage.color }}" stop-opacity="0.95"/>
+                                <stop offset="100%" stop-color="{{ stage.color }}" stop-opacity="0.78"/>
+                            </linearGradient>
+                            {% endfor %}
+                        </defs>
+                        {% for stage in stages %}
+                        <g class="funnel-stage" data-stage="{{ stage.key }}" style="animation-delay: {{ forloop.counter0 }}00ms;"
+                           hx-get="{% url 'cdd_funnel:stage_drilldown' stage.key %}"
+                           hx-target="#drilldown" hx-swap="innerHTML"
+                           hx-indicator="#drilldown-indicator"
+                           hx-on:click="document.querySelectorAll('.funnel-stage, .stage-row').forEach(el => el.classList.remove('active')); this.classList.add('active'); document.querySelector('.stage-row[data-stage=\'{{ stage.key }}\']')?.classList.add('active');">
+                            <polygon points="{{ stage.polygon_points }}" fill="url(#grad-{{ stage.key }})"/>
+                            <title>{{ stage.label }} — {{ stage.count|intcomma }} {% translate 'villages' %} ({{ stage.pct_of_total }}%)</title>
+                            {% if stage.width_mid >= 220 %}
+                                <text class="funnel-count" x="50%" y="{{ stage.label_y|add:-4 }}" text-anchor="middle">{{ stage.count|intcomma }}</text>
+                                <text class="funnel-label" x="50%" y="{{ stage.label_y|add:16 }}" text-anchor="middle">{{ stage.label }}</text>
+                            {% elif stage.width_mid >= 110 %}
+                                <text class="funnel-count-sm" x="50%" y="{{ stage.label_y|add:6 }}" text-anchor="middle">{{ stage.count|intcomma }}</text>
+                            {% elif stage.width_mid >= 36 %}
+                                <text class="funnel-count-sm" x="50%" y="{{ stage.label_y|add:5 }}" text-anchor="middle">{{ stage.count|intcomma }}</text>
+                            {% endif %}
+                        </g>
+                        {% endfor %}
+                    </svg>
+                    {% else %}
+                    <div class="drilldown-empty">
+                        <p>{% translate 'No villages found in the dataset.' %}</p>
+                    </div>
+                    {% endif %}
+                </div>
+
+                <div class="stage-list">
+                    {% for stage in stages %}
+                    <div class="stage-row" data-stage="{{ stage.key }}"
+                         hx-get="{% url 'cdd_funnel:stage_drilldown' stage.key %}"
+                         hx-target="#drilldown" hx-swap="innerHTML"
+                         hx-indicator="#drilldown-indicator"
+                         hx-on:click="document.querySelectorAll('.funnel-stage, .stage-row').forEach(el => el.classList.remove('active')); this.classList.add('active'); document.querySelector('.funnel-stage[data-stage=\'{{ stage.key }}\']')?.classList.add('active');">
+                        <span class="stage-dot" style="background: {{ stage.color }};">{{ forloop.counter }}</span>
+                        <div>
+                            <div class="stage-name">{{ stage.label }}</div>
+                            <div class="stage-desc">{{ stage.description }}</div>
+                        </div>
+                        <div class="stage-metric">
+                            <div class="stage-count">{{ stage.count|intcomma }}</div>
+                            {% if not forloop.first %}
+                            <div class="stage-conv">
+                                <span class="conv-arrow">↓</span>
+                                <span>{{ stage.pct_from_previous }}%</span>
+                            </div>
+                            {% else %}
+                            <div class="stage-conv"><span>{% translate 'baseline' %}</span></div>
+                            {% endif %}
+                        </div>
+                        <span class="stage-chevron" aria-hidden="true" title="{% translate 'View villages' %}">
+                            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+                        </span>
+                        {% if not forloop.first %}
+                        <div class="conv-bar">
+                            <div class="conv-fill" style="width: 0%; background: {{ stage.color }};" data-target-width="{{ stage.pct_from_previous }}"></div>
+                        </div>
+                        {% endif %}
+                    </div>
+                    {% endfor %}
+                </div>
+            </div>
+
+            <div class="drilldown-section">
+                <div class="drilldown-section-head">
+                    <div>
+                        <h3 class="drilldown-section-title">{% translate 'Villages at the selected stage' %}</h3>
+                        <p class="drilldown-section-sub">{% translate 'Click any funnel band or stage card above to swap this list.' %}</p>
+                    </div>
+                    <span id="drilldown-indicator" class="htmx-indicator">
+                        <span class="spinner-dot"></span><span class="spinner-dot"></span><span class="spinner-dot"></span>
+                    </span>
+                </div>
+                <div id="drilldown"
+                     {% if first_stage %}hx-get="{% url 'cdd_funnel:stage_drilldown' first_stage.key %}"{% endif %}
+                     hx-trigger="load"
+                     hx-swap="innerHTML"
+                     hx-indicator="#drilldown-indicator">
+                    <div class="drilldown-empty">
+                        <span class="spinner-dot"></span><span class="spinner-dot"></span><span class="spinner-dot"></span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="dist-grid">
+            <div class="dist-card">
+                <div class="dist-head">
+                    <div>
+                        <h3 class="dist-title">{% translate 'Planning tasks — by status' %}</h3>
+                        <div class="dist-subtitle">{% translate 'Across all CDD phases & activities' %}</div>
+                    </div>
+                    <div class="dist-subtitle">{{ task_chart.total|intcomma }} {% translate 'tasks' %}</div>
+                </div>
+                <div class="dist-canvas-wrap">
+                    {% if task_chart.total %}
+                    <canvas id="tasks-donut"></canvas>
+                    {% else %}
+                    <div class="dist-empty">{% translate 'No task data yet.' %}</div>
+                    {% endif %}
+                </div>
+                {% if task_chart.items %}
+                <div class="dist-legend">
+                    {% for item in task_chart.items %}
+                    <div class="dist-legend-item">
+                        <span class="dist-legend-color" style="background: {{ item.color }};"></span>
+                        <span>{{ item.label }}</span>
+                        <span class="dist-legend-count">{{ item.count|intcomma }}</span>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </div>
+
+            <div class="dist-card">
+                <div class="dist-head">
+                    <div>
+                        <h3 class="dist-title">{% translate 'Investments — by project status' %}</h3>
+                        <div class="dist-subtitle">{% translate 'Pipeline of community investments' %}</div>
+                    </div>
+                    <div class="dist-subtitle">{{ investment_chart.total|intcomma }} {% translate 'investments' %}</div>
+                </div>
+                <div class="dist-canvas-wrap">
+                    {% if investment_chart.total %}
+                    <canvas id="investments-donut"></canvas>
+                    {% else %}
+                    <div class="dist-empty">{% translate 'No investment data yet.' %}</div>
+                    {% endif %}
+                </div>
+                {% if investment_chart.items %}
+                <div class="dist-legend">
+                    {% for item in investment_chart.items %}
+                    <div class="dist-legend-item">
+                        <span class="dist-legend-color" style="background: {{ item.color }};"></span>
+                        <span>{{ item.label }}</span>
+                        <span class="dist-legend-count">{{ item.count|intcomma }}</span>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% endif %}
+            </div>
+
+            <div class="dist-card">
+                <div class="dist-head">
+                    <div>
+                        <h3 class="dist-title">{% translate 'Top sectors' %}</h3>
+                        <div class="dist-subtitle">{% translate 'Where investments concentrate' %}</div>
+                    </div>
+                </div>
+                {% if summary.sector_breakdown %}
+                <div class="sector-rows">
+                    {% for s in summary.sector_breakdown %}
+                    <div class="sector-row">
+                        <div class="sector-name" title="{{ s.name }}">{{ s.name }}</div>
+                        <div class="sector-bar">
+                            <div class="sector-bar-fill" style="width: 0%;" data-target-width="{% widthratio s.count max_sector_count 100 %}"></div>
+                        </div>
+                        <div class="sector-count">
+                            {{ s.count|intcomma }}
+                            <span class="sector-cost">{{ s.total_cost|intcomma }}</span>
+                        </div>
+                    </div>
+                    {% endfor %}
+                </div>
+                {% else %}
+                <div class="dist-empty">{% translate 'No sector data yet.' %}</div>
+                {% endif %}
+            </div>
+        </div>
+
+    </div>
+</div>
+{% endblock %}
+
+{% block javascript %}
+    {{ block.super }}
+    <script src="{% static 'AdminLTE/plugins/chart.js/Chart.bundle.min.js' %}"></script>
+    <script>
+    (function () {
+        // Timestamp
+        var stamp = "{{ summary.generated_at }}";
+        try {
+            var d = new Date(stamp);
+            document.getElementById('hero-updated-at').textContent = d.toLocaleString();
+        } catch (e) { /* noop */ }
+
+        // Animate conversion + sector bars in
+        requestAnimationFrame(function () {
+            document.querySelectorAll('.conv-fill, .sector-bar-fill').forEach(function (el) {
+                var w = parseFloat(el.getAttribute('data-target-width') || '0');
+                if (isNaN(w)) w = 0;
+                if (w > 100) w = 100;
+                el.style.width = w + '%';
+            });
+        });
+
+        // Donut: tasks
+        var tasksCanvas = document.getElementById('tasks-donut');
+        if (tasksCanvas && window.Chart) {
+            new Chart(tasksCanvas.getContext('2d'), {
+                type: 'doughnut',
+                data: {
+                    labels: {{ task_chart.labels_json|safe }},
+                    datasets: [{
+                        data: {{ task_chart.values_json|safe }},
+                        backgroundColor: {{ task_chart.colors_json|safe }},
+                        borderColor: '#ffffff',
+                        borderWidth: 2
+                    }]
+                },
+                options: {
+                    responsive: true, maintainAspectRatio: false,
+                    cutoutPercentage: 65,
+                    legend: { display: false },
+                    tooltips: {
+                        callbacks: {
+                            label: function (item, data) {
+                                var label = data.labels[item.index] || '';
+                                var value = data.datasets[0].data[item.index] || 0;
+                                return label + ': ' + value.toLocaleString();
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        // Donut: investments
+        var invCanvas = document.getElementById('investments-donut');
+        if (invCanvas && window.Chart) {
+            new Chart(invCanvas.getContext('2d'), {
+                type: 'doughnut',
+                data: {
+                    labels: {{ investment_chart.labels_json|safe }},
+                    datasets: [{
+                        data: {{ investment_chart.values_json|safe }},
+                        backgroundColor: {{ investment_chart.colors_json|safe }},
+                        borderColor: '#ffffff',
+                        borderWidth: 2
+                    }]
+                },
+                options: {
+                    responsive: true, maintainAspectRatio: false,
+                    cutoutPercentage: 65,
+                    legend: { display: false },
+                    tooltips: {
+                        callbacks: {
+                            label: function (item, data) {
+                                var label = data.labels[item.index] || '';
+                                var value = data.datasets[0].data[item.index] || 0;
+                                return label + ': ' + value.toLocaleString();
+                            }
+                        }
+                    }
+                }
+            });
+        }
+
+        // Mark first stage as visually active to match the auto-loaded drilldown.
+        var firstStageKey = "{{ first_stage.key|default:'' }}";
+        if (firstStageKey) {
+            document.querySelectorAll('.funnel-stage[data-stage="' + firstStageKey + '"], .stage-row[data-stage="' + firstStageKey + '"]').forEach(function (el) {
+                el.classList.add('active');
+            });
+        }
+
+        // Mark drilldown panel as loading during HTMX requests
+        document.body.addEventListener('htmx:beforeRequest', function (evt) {
+            var target = evt.detail && evt.detail.target;
+            if (target && target.id === 'drilldown') {
+                target.classList.add('cdd-loading');
+            }
+        });
+        document.body.addEventListener('htmx:afterSwap', function (evt) {
+            var target = evt.detail && evt.detail.target;
+            if (target && target.id === 'drilldown') {
+                target.classList.remove('cdd-loading');
+                // After a click-driven swap, gently bring the drilldown into view.
+                // Skip the initial load (triggered by hx-trigger="load") so the
+                // page does not auto-scroll on first render.
+                var trigger = evt.detail && evt.detail.requestConfig && evt.detail.requestConfig.triggeringEvent;
+                if (trigger && trigger.type === 'click') {
+                    var rect = target.getBoundingClientRect();
+                    var vh = window.innerHeight || document.documentElement.clientHeight;
+                    if (rect.top < 60 || rect.bottom > vh) {
+                        target.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+                    }
+                }
+            }
+        });
+    })();
+    </script>
+{% endblock %}

--- a/cosomis/cdd_funnel/templates/village_list.html
+++ b/cosomis/cdd_funnel/templates/village_list.html
@@ -26,18 +26,22 @@
 							</tr>
 							</thead>
 							<tbody>
-							{% with villages as villages %}
-								{% for village in villages %}
-									<tr>
-										<td class="text-left">
-											<a href="{% url 'administrativelevels:village_detail' village.id %}">
-												{{ village.name }}
-											</a>
-										</td>
-										<td>{{ village.uncompleted_tasks }}</td>
-									</tr>
-								{% endfor %}
-							{% endwith %}
+							{% for village in villages %}
+								<tr>
+									<td class="text-left">
+										<a href="{% url 'administrativelevels:village_detail' village.id %}">
+											{{ village.name }}
+										</a>
+									</td>
+									<td>{{ village.uncompleted_tasks }}</td>
+								</tr>
+							{% empty %}
+								<tr>
+									<td colspan="2" class="text-center text-muted py-3">
+										{% translate 'No villages with uncompleted tasks.' %}
+									</td>
+								</tr>
+							{% endfor %}
 							</tbody>
 						</table>
 						<div class="pagination">

--- a/cosomis/cdd_funnel/urls.py
+++ b/cosomis/cdd_funnel/urls.py
@@ -1,11 +1,13 @@
 from django.urls import path
-from rest_framework import routers
 
-from cdd_funnel.views import CddFunnelView
-
-router = routers.DefaultRouter()
+from cdd_funnel.views import CddFunnelView, StageDrilldownView
 
 app_name = 'cdd_funnel'
 urlpatterns = [
     path('', CddFunnelView.as_view(), name='main_funnel'),
+    path(
+        'stage/<str:stage_key>/',
+        StageDrilldownView.as_view(),
+        name='stage_drilldown',
+    ),
 ]

--- a/cosomis/cdd_funnel/views.py
+++ b/cosomis/cdd_funnel/views.py
@@ -1,43 +1,135 @@
+import json
+
 from django.core.paginator import Paginator
+from django.http import Http404
+from django.utils.translation import gettext_lazy as _
 from django.views import generic
 
-from administrativelevels.models import Task, AdministrativeLevel
+from administrativelevels.models import Task
 from cosomis.mixins import PageMixin
-from django.utils.translation import gettext_lazy as _
+from investments.models import Investment
+
+from cdd_funnel.services import CountryCddFunnelService
 
 
-class CddFunnelView(PageMixin, generic.ListView):
-    template_name = "village_list.html"
-    model = AdministrativeLevel
+# Display labels for raw Task / Investment status codes so the template can
+# render them without re-deriving the choices map.
+TASK_STATUS_LABELS = {
+    Task.NOT_STARTED: _("Not started"),
+    Task.IN_PROGRESS: _("In progress"),
+    Task.COMPLETED: _("Completed"),
+    Task.ERROR: _("Error"),
+}
+
+TASK_STATUS_COLORS = {
+    Task.NOT_STARTED: "#cbd5e1",
+    Task.IN_PROGRESS: "#f59e0b",
+    Task.COMPLETED: "#10b981",
+    Task.ERROR: "#ef4444",
+}
+
+INVESTMENT_STATUS_LABELS = {
+    Investment.NOT_FUNDED: _("Not funded"),
+    Investment.FUNDED: _("Funded"),
+    Investment.IN_PROGRESS: _("In progress"),
+    Investment.COMPLETED: _("Completed"),
+    Investment.PAUSED: _("Paused"),
+}
+
+INVESTMENT_STATUS_COLORS = {
+    Investment.NOT_FUNDED: "#cbd5e1",
+    Investment.FUNDED: "#6366f1",
+    Investment.IN_PROGRESS: "#f59e0b",
+    Investment.COMPLETED: "#10b981",
+    Investment.PAUSED: "#9ca3af",
+}
+
+
+def _build_chart_dataset(distribution, label_map, color_map):
+    labels, values, colors, items = [], [], [], []
+    for key, label in label_map.items():
+        count = distribution.get(key, 0)
+        if count == 0:
+            continue
+        labels.append(str(label))
+        values.append(count)
+        colors.append(color_map.get(key, "#9ca3af"))
+        items.append({"label": str(label), "count": count, "color": color_map.get(key, "#9ca3af")})
+    return {
+        "labels_json": json.dumps(labels),
+        "values_json": json.dumps(values),
+        "colors_json": json.dumps(colors),
+        "items": items,
+        "total": sum(values),
+    }
+
+
+class CddFunnelView(PageMixin, generic.TemplateView):
+    template_name = "cdd_funnel.html"
     title = _("CDD Funnel")
-    paginate_by = 10
+    active_level1 = "cdd_funnel"
 
     def get_context_data(self, **kwargs):
-        ctx = super(CddFunnelView, self).get_context_data(**kwargs)
-        villages = list()
-        admin_levels = self.object_list.filter(type=AdministrativeLevel.VILLAGE)
-        paginator = Paginator(admin_levels, 25)  # Show 25 contacts per page.
+        ctx = super().get_context_data(**kwargs)
+        summary = CountryCddFunnelService().get_summary()
 
-        page_number = self.request.GET.get("page")
-        page_obj = paginator.get_page(page_number)
-        ctx['page_number'] = page_number
-        ctx['page_obj'] = page_obj
-        for admin_level in page_obj:
-            uncompleted_tasks = 0
-            for phase in admin_level.phases.all().order_by("order"):
-                for activity in phase.activities.all().order_by("order"):
-                    for task in activity.tasks.all().order_by("order"):
-                        if task.status != Task.COMPLETED:
-                            uncompleted_tasks = uncompleted_tasks + 1
+        task_chart = _build_chart_dataset(
+            summary.phase_status_dist, TASK_STATUS_LABELS, TASK_STATUS_COLORS
+        )
+        investment_chart = _build_chart_dataset(
+            summary.investment_status_dist,
+            INVESTMENT_STATUS_LABELS,
+            INVESTMENT_STATUS_COLORS,
+        )
 
-            if uncompleted_tasks != 0:
-                villages.append(
-                    {
-                        'name': admin_level.name,
-                        'uncompleted_tasks': uncompleted_tasks,
-                        'id': admin_level.id,
-                    }
-                )
-        ctx['villages'] = villages
+        max_sector_count = max(
+            (s["count"] for s in summary.sector_breakdown), default=0
+        )
+
+        ctx.update(
+            {
+                "summary": summary,
+                "stages": summary.stages,
+                "first_stage": summary.stages[0] if summary.stages else None,
+                "last_stage": summary.stages[-1] if summary.stages else None,
+                "engaged_stage": next(
+                    (s for s in summary.stages if s.key == "engaged"), None
+                ),
+                "funded_stage": next(
+                    (s for s in summary.stages if s.key == "funded"), None
+                ),
+                "task_chart": task_chart,
+                "investment_chart": investment_chart,
+                "max_sector_count": max_sector_count,
+            }
+        )
         return ctx
 
+
+class StageDrilldownView(generic.TemplateView):
+    """HTMX fragment: list of villages currently at a given funnel stage."""
+
+    template_name = "_stage_villages.html"
+    paginate_by = 24
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        stage_key = kwargs.get("stage_key")
+        service = CountryCddFunnelService()
+        stage_label = service.stage_label(stage_key)
+        if not stage_label:
+            raise Http404("Unknown stage")
+
+        villages_qs = service.get_villages_at_stage(stage_key)
+        paginator = Paginator(villages_qs, self.paginate_by)
+        page_obj = paginator.get_page(self.request.GET.get("page"))
+
+        ctx.update(
+            {
+                "stage_key": stage_key,
+                "stage_label": stage_label,
+                "page_obj": page_obj,
+                "total": paginator.count,
+            }
+        )
+        return ctx


### PR DESCRIPTION
#### What does this PR do?

This branch bundles two related changes that ship together because the second supersedes the original blank-page fix from the first:

**1. `feat(adm-levels): dataset-aware detail pages + descendant aggregations`** (previously committed on this branch)

**2. `feat(cdd-funnel): country-wide interactive funnel visualization`** (new in this PR)

Replaces the previous `/en/cdd-funnel/` page — which rendered as a blank table on the Benin dataset and as a paginated village list with uncompleted-task counts on Togo — with an interactive country-wide funnel of the CDD process.

Backend
- New `CountryCddFunnelService` ([cosomis/cdd_funnel/services.py](cosomis/cdd_funnel/services.py)) aggregates the 7-stage funnel (`All Villages → CDD Engaged → Planning Complete → Priorities Identified → Funded → In Execution → Completed`) plus task-status and investment-status distributions, sector breakdown, and cost roll-ups.
- Funnel polygon geometry is forced monotonically non-increasing so the funnel always reads as a funnel even when downstream stages have a larger raw count than the one above (e.g. villages with investment priorities identified before every planning task is completed). Labels still reflect the true counts.
- `CddFunnelView` rewritten as a `TemplateView`. New `StageDrilldownView` renders an HTMX fragment of villages currently at a given stage, paginated 24 per page.

Frontend
- New [cosomis/cdd_funnel/templates/cdd_funnel.html](cosomis/cdd_funnel/templates/cdd_funnel.html) with a KPI hero strip, an animated gradient SVG funnel (click any band or stage card to drill), two Chart.js donuts (task status, investment status), a sector bar chart, and an in-panel drilldown that auto-loads the first stage on page open and smooth-scrolls into view on subsequent clicks.
- New [cosomis/cdd_funnel/templates/_stage_villages.html](cosomis/cdd_funnel/templates/_stage_villages.html) renders the HTMX village-chip grid with HTMX-paginated controls.

Dataset awareness
- Also fixes the original blank-page bug: the old village filter used a hard-coded `type='Village'` literal that returned zero rows on Benin (lowercase `'village'`). All filters now go through `AdministrativeLevel.type_filter_q()` per CLAUDE.md guidance.

Notes for the reviewer
- `cdd_funnel/templates/village_list.html` is now orphaned (no `template_name` reference). Left in place for this commit; happy to drop in a follow-up if you prefer.
- New translatable strings added — run `make generate-translations` to land them in the `en`/`fr` catalogs before release.
- Chart.js v2 is loaded from the existing `static/AdminLTE/plugins/chart.js/Chart.bundle.min.js`. HTMX is already wired globally via [cosomis/cosomis/templates/layouts/foot.html](cosomis/cosomis/templates/layouts/foot.html). No new dependencies.

#### How to verify functionality?

- [ ] Visit `/en/cdd-funnel/` on the Benin dataset — page should render the full funnel (not blank), KPI hero, donuts, and an auto-loaded "All Villages" drilldown grid below the funnel.
- [ ] Click each of the 7 stage cards on the right; the drilldown swaps to show the villages at that stage, and the corresponding SVG band gets the active border highlight.
- [ ] Click directly on a band of the SVG funnel; same behavior, plus the matching right-side stage card highlights.
- [ ] Click a village chip in the drilldown — opens `administrativelevels:village_detail`.
- [ ] Use pagination ("Next ›") inside the drilldown — pagination is HTMX-driven and replaces the grid in place.
- [ ] Repeat the above on the Togo dataset; villages should also render, confirming no regression from the `type_filter_q` change.
- [ ] Hover any funnel band — native tooltip shows stage name, count, and percentage.
- [ ] Confirm the funnel is visually narrowing top-to-bottom even though `Priorities Identified` (641) is numerically larger than `Planning Complete` (429) on the live Benin DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)