### PR TITLE
feat(adm-filters): dataset-aware labels + hide single-root dropdown

### DIFF
--- a/cosomis/administrativelevels/forms.py
+++ b/cosomis/administrativelevels/forms.py
@@ -198,7 +198,7 @@ class VillageSearchForm(forms.Form):
         label=_("Canton"),
     )
 
-    def __init__(self, *args, hierarchy_labels=None, **kwargs):
+    def __init__(self, *args, hierarchy_labels=None, single_region=None, **kwargs):
         super().__init__(*args, **kwargs)
         # `hierarchy_labels` is root-first: [region, prefecture, commune, canton, leaf].
         # Override the static labels with whatever the dataset actually calls each
@@ -211,6 +211,15 @@ class VillageSearchForm(forms.Form):
             ):
                 if label and field_name in self.fields:
                     self.fields[field_name].label = label
+        # When the dataset has a single root the region dropdown is hidden in
+        # the template, so pre-load the prefecture queryset with its direct
+        # children to make the next-level dropdown immediately usable.
+        if single_region:
+            self.fields["prefecture"].queryset = (
+                AdministrativeLevel.objects.filter(parent=single_region).filter(
+                    AdministrativeLevel.type_filter_q(AdministrativeLevel.PREFECTURE)
+                )
+            )
 
 class FinancialPartnerForm(forms.Form):
     name = forms.CharField()
@@ -230,6 +239,8 @@ class AttachmentFilterForm(forms.Form):
     activity = forms.ChoiceField(widget=Select(attrs={'empty-option': '---------'}), required=False, label=_("Activity"))
     task = forms.ChoiceField(widget=Select(attrs={'empty-option': '---------'}), required=False, label=_("Task"))
     administrative_level = forms.ModelChoiceField(
-        queryset=AdministrativeLevel.objects.filter(type=AdministrativeLevel.VILLAGE),
+        queryset=AdministrativeLevel.objects.filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE)
+        ),
         widget=Select(attrs={'empty-option': '---------'}), required=False, label=_("Administrative level")
     )

--- a/cosomis/administrativelevels/models.py
+++ b/cosomis/administrativelevels/models.py
@@ -170,6 +170,25 @@ class AdministrativeLevel(BaseModel):
             cur = cur.children.first()
         return labels
 
+    @classmethod
+    def get_filter_labels(cls):
+        """Return {canonical_key: display_label} for filter UIs.
+
+        Pulls labels from the dataset's actual vocabulary via
+        get_hierarchy_labels() (so Benin sees Country/Département/...) and
+        falls back to Togo's translated English when the data has fewer
+        than five levels.
+        """
+        fallback = (
+            _("Region"), _("Prefecture"), _("Commune"), _("Canton"), _("Village"),
+        )
+        keys = ("region", "prefecture", "commune", "canton", "village")
+        labels = cls.get_hierarchy_labels() or []
+        return {
+            key: (labels[i] if i < len(labels) and labels[i] else fallback[i])
+            for i, key in enumerate(keys)
+        }
+
     def is_village(self):
         return self.matches_type(self.type, self.VILLAGE)
 

--- a/cosomis/administrativelevels/templates/administrative_level/list.html
+++ b/cosomis/administrativelevels/templates/administrative_level/list.html
@@ -142,7 +142,7 @@
 
                     <div class="adl-filter">
                         {% for field in form %}
-                            <div class="form-group row">
+                            <div class="form-group row"{% if single_region and field.name == 'region' %} style="display: none;"{% endif %}>
                                 <label class="col-4 col-form-label">{{ field.label }}</label>
                                 <div class="col-8">{{ field }}</div>
                                 <a id="check_{{ field.name }}" href="" style="display: none;"></a>
@@ -235,7 +235,7 @@
           // Parcourir les identifiants et griser les champs sauf id_region
           administrative_level_ids.forEach(function(id) {
             var element = document.getElementById(id);
-            if (id !== "id_region") {
+            if (id !== "id_region"{% if single_region %} && id !== "id_prefecture"{% endif %}) {
               element.disabled = true; // Désactive le champ
 
             }

--- a/cosomis/administrativelevels/templates/attachments/attachments.html
+++ b/cosomis/administrativelevels/templates/attachments/attachments.html
@@ -436,36 +436,54 @@
                         <input type="hidden" name="type" value="{{ query_strings_raw.type }}">
                         <div class="row">
                             <div class="col-md-6">
-                                <div class="form-group">
-                                    <div class="form-label">
-                                        <label for="id_region">{% translate 'Region' %}</label>
-                                    </div>
-                                    <div class="form-select-row">
+                                {% if single_region %}
+                                    {# Single-root dataset: hide the redundant top-level select but keep it in the DOM for the JS cascade. #}
+                                    <div class="form-group" style="display: none;">
                                         <select class="form-control" name="region" id="id_region" style="width: 100%;">
-                                            <option selected value="">---</option>
-                                            {% for region in regions %}
-                                                {% if 'region' in filter_hierarchy_query_strings and filter_hierarchy_query_strings.region == region.id %}
-                                                    <option value="{{ region.id }}" selected>{{ region.name }}</option>
-                                                {% else %}
-                                                    <option value="{{ region.id }}">{{ region.name }}</option>
-                                                {% endif %}
-                                            {% endfor %}
+                                            <option value="{{ single_region.id }}" selected>{{ single_region.name }}</option>
                                         </select>
                                     </div>
-                                </div>
+                                {% else %}
+                                    <div class="form-group">
+                                        <div class="form-label">
+                                            <label for="id_region">{{ adm_labels.region }}</label>
+                                        </div>
+                                        <div class="form-select-row">
+                                            <select class="form-control" name="region" id="id_region" style="width: 100%;">
+                                                <option selected value="">---</option>
+                                                {% for region in regions %}
+                                                    {% if 'region' in filter_hierarchy_query_strings and filter_hierarchy_query_strings.region == region.id %}
+                                                        <option value="{{ region.id }}" selected>{{ region.name }}</option>
+                                                    {% else %}
+                                                        <option value="{{ region.id }}">{{ region.name }}</option>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    </div>
+                                {% endif %}
                                 <div class="form-group">
                                     <div class="form-label">
-                                        <label for="id_prefecture">{% translate 'Prefecture' %}</label>
+                                        <label for="id_prefecture">{{ adm_labels.prefecture }}</label>
                                     </div>
                                     <div class="form-select-row">
-                                        <select class="form-control" name="prefecture" id="id_prefecture" style="width: 100%;" disabled>
+                                        <select class="form-control" name="prefecture" id="id_prefecture" style="width: 100%;"{% if not single_region %} disabled{% endif %}>
                                             <option selected value="">---</option>
+                                            {% if single_region %}
+                                                {% for prefecture in prefectures %}
+                                                    {% if 'prefecture' in filter_hierarchy_query_strings and filter_hierarchy_query_strings.prefecture == prefecture.id %}
+                                                        <option value="{{ prefecture.id }}" selected>{{ prefecture.name }}</option>
+                                                    {% else %}
+                                                        <option value="{{ prefecture.id }}">{{ prefecture.name }}</option>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            {% endif %}
                                         </select>
                                     </div>
                                 </div>
                                 <div class="form-group">
                                     <div class="form-label">
-                                        <label for="id_commune">{% translate 'Commune' %}</label>
+                                        <label for="id_commune">{{ adm_labels.commune }}</label>
                                     </div>
                                     <div class="form-select-row">
                                         <select class="form-control" name="commune" id="id_commune" style="width: 100%;" disabled>
@@ -475,7 +493,7 @@
                                 </div>
                                 <div class="form-group">
                                     <div class="form-label">
-                                        <label for="id_canton">{% translate 'Canton' %}</label>
+                                        <label for="id_canton">{{ adm_labels.canton }}</label>
                                     </div>
                                     <div class="form-select-row">
                                         <select class="form-control" name="canton" id="id_canton" style="width: 100%;" disabled>
@@ -487,7 +505,7 @@
                             <div class="col-md-6">
                                 <div class="form-group">
                                     <div class="form-label">
-                                        <label for="id_village">{% translate 'Village' %}</label>
+                                        <label for="id_village">{{ adm_labels.village }}</label>
                                     </div>
                                     <div class="form-select-row">
                                         <select class="form-control" name="village" id="id_village" style="width: 100%;" disabled>

--- a/cosomis/administrativelevels/utils/views.py
+++ b/cosomis/administrativelevels/utils/views.py
@@ -232,19 +232,37 @@ class FillAttachmentSelectFilters(generics.GenericAPIView):
         select_type = request.POST['type']
         child_qs = list()
         if select_type == 'region':
-            parent_qs = AdministrativeLevel.objects.filter(id=request.POST['value'], type=AdministrativeLevel.REGION)
-            child_qs = AdministrativeLevel.objects.filter(parent=Subquery(parent_qs.values('id')), type=AdministrativeLevel.PREFECTURE)
+            parent_qs = AdministrativeLevel.objects.filter(id=request.POST['value']).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.REGION)
+            )
+            child_qs = AdministrativeLevel.objects.filter(parent=Subquery(parent_qs.values('id'))).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.PREFECTURE)
+            )
         elif select_type == 'prefecture':
-            parent_qs = AdministrativeLevel.objects.filter(id=request.POST['value'], type=AdministrativeLevel.PREFECTURE)
-            child_qs = AdministrativeLevel.objects.filter(parent=Subquery(parent_qs.values('id')), type=AdministrativeLevel.COMMUNE)
+            parent_qs = AdministrativeLevel.objects.filter(id=request.POST['value']).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.PREFECTURE)
+            )
+            child_qs = AdministrativeLevel.objects.filter(parent=Subquery(parent_qs.values('id'))).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.COMMUNE)
+            )
         elif select_type == 'commune':
-            parent_qs = AdministrativeLevel.objects.filter(id=request.POST['value'], type=AdministrativeLevel.COMMUNE)
-            child_qs = AdministrativeLevel.objects.filter(parent=Subquery(parent_qs.values('id')), type=AdministrativeLevel.CANTON)
+            parent_qs = AdministrativeLevel.objects.filter(id=request.POST['value']).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.COMMUNE)
+            )
+            child_qs = AdministrativeLevel.objects.filter(parent=Subquery(parent_qs.values('id'))).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.CANTON)
+            )
         elif select_type == 'canton':
-            parent_qs = AdministrativeLevel.objects.filter(id=request.POST['value'], type=AdministrativeLevel.CANTON)
-            child_qs = AdministrativeLevel.objects.filter(parent=Subquery(parent_qs.values('id')), type=AdministrativeLevel.VILLAGE)
+            parent_qs = AdministrativeLevel.objects.filter(id=request.POST['value']).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.CANTON)
+            )
+            child_qs = AdministrativeLevel.objects.filter(parent=Subquery(parent_qs.values('id'))).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE)
+            )
         elif select_type == 'village':
-            parent_obj = AdministrativeLevel.objects.get(id=request.POST['value'], type=AdministrativeLevel.VILLAGE)
+            parent_obj = AdministrativeLevel.objects.filter(id=request.POST['value']).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE)
+            ).get()
             child_qs = Phase.objects.filter(village=parent_obj)
         elif select_type == 'phase':
             # parent_obj = Phase.objects.filter(id=request.POST['value'])

--- a/cosomis/administrativelevels/views.py
+++ b/cosomis/administrativelevels/views.py
@@ -159,7 +159,16 @@ class AdministrativeLevelSearchListView(PageMixin, LoginRequiredApproveRequiredM
         # the dataset's vocabulary (Country/Département/... for Benin,
         # Region/Prefecture/... for Togo, etc.).
         hierarchy_labels = AdministrativeLevel.get_hierarchy_labels()
-        ctx["form"] = VillageSearchForm(hierarchy_labels=hierarchy_labels)
+        # When the dataset has a single root (e.g. Benin = one "country" row),
+        # hide the top-level dropdown and pre-populate the next level.
+        roots = AdministrativeLevel.objects.filter(parent__isnull=True)
+        single_region = roots.first() if roots.count() == 1 else None
+        ctx["single_region"] = single_region
+        ctx["form"] = VillageSearchForm(
+            hierarchy_labels=hierarchy_labels,
+            single_region=single_region,
+            initial={"region": single_region} if single_region else None,
+        )
         ctx["search"] = self.request.GET.get("search", None)
         ctx["type"] = self.request.GET.get("type", "Village")
         ctx["current_language"] = translation.get_language()
@@ -1515,10 +1524,29 @@ class AttachmentListView(PageMixin, LoginRequiredApproveRequiredMixin, ListView)
     def get_context_data(self, **kwargs):
         context = super(AttachmentListView, self).get_context_data(**kwargs)
 
-        context["regions"] = AdministrativeLevel.objects.filter(
-            type=AdministrativeLevel.REGION
+        regions_qs = AdministrativeLevel.objects.filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.REGION)
+        )
+        context["regions"] = regions_qs
+        # When the dataset has a single root (e.g. Benin = one "country" row),
+        # the top-level dropdown is just decoration. Auto-select it server-side
+        # and pre-load its prefectures so the modal starts at the next level.
+        single_region = regions_qs.first() if regions_qs.count() == 1 else None
+        context["single_region"] = single_region
+        context["prefectures"] = (
+            AdministrativeLevel.objects.filter(parent=single_region).filter(
+                AdministrativeLevel.type_filter_q(AdministrativeLevel.PREFECTURE)
+            )
+            if single_region
+            else AdministrativeLevel.objects.none()
         )
         context['phases'] = Phase.objects.all().values_list('name', flat=True).distinct()
+
+        # Use the dataset's own level names so the modal/chip labels read
+        # "Country / Département / ... / Village" on Benin instead of the
+        # Togo-flavoured fallback.
+        adm_labels = AdministrativeLevel.get_filter_labels()
+        context["adm_labels"] = adm_labels
 
         query_params: dict = self.request.GET
 
@@ -1530,7 +1558,7 @@ class AttachmentListView(PageMixin, LoginRequiredApproveRequiredMixin, ListView)
             context["babylong_query_params"] = '&' + '&'.join(babylong_query_params_list)
 
         context["type_links"] = self._build_type_links(query_params)
-        context["active_filter_chips"] = self._build_active_chips(query_params)
+        context["active_filter_chips"] = self._build_active_chips(query_params, adm_labels, single_region)
 
         form = AttachmentFilterForm()
 
@@ -1628,15 +1656,9 @@ class AttachmentListView(PageMixin, LoginRequiredApproveRequiredMixin, ListView)
             "active": active,
         }
 
-    def _build_active_chips(self, query_params):
+    def _build_active_chips(self, query_params, adm_label_keys, single_region=None):
         chips = []
-        adm_label_keys = {
-            "region": _("Region"),
-            "prefecture": _("Prefecture"),
-            "commune": _("Commune"),
-            "canton": _("Canton"),
-            "village": _("Village"),
-        }
+        single_region_id = str(single_region.id) if single_region else None
 
         attachment_type = query_params.get("type")
         if attachment_type in (Attachment.PHOTO, Attachment.DOCUMENT):
@@ -1650,6 +1672,8 @@ class AttachmentListView(PageMixin, LoginRequiredApproveRequiredMixin, ListView)
         for key, prefix in adm_label_keys.items():
             value = query_params.get(key)
             if not value:
+                continue
+            if key == "region" and single_region_id and value == single_region_id:
                 continue
             try:
                 adm_lvl = AdministrativeLevel.objects.get(id=int(value))

--- a/cosomis/dashboard/templates/dashboard_summary.html
+++ b/cosomis/dashboard/templates/dashboard_summary.html
@@ -113,53 +113,63 @@
                                             {% endfor %}
                                         </select>
                                     </div>
-                                    <div class="form-group">
-                                        <label for="region-select-id">{% translate 'Region' %}</label>
-                                        <select class="form-control" name="region-filter"
-                                        	empty-option="{% translate 'Region' %}" style="width: 100%;" id="region-select-id">
-                                            <option selected value="">{% translate 'Region' %}</option>
-                                            {% for region in regions %}
-                                                <option value="{{ region.id }}" {% if query_strings_raw|get_item:'region-filter' == region.id %}selected{% endif %}>{{ region.name }}</option>
-                                            {% endfor %}
-                                        </select>
-                                    </div>
+                                    {% if single_region %}
+                                        {# Single-root dataset: keep the select in the DOM for the JS cascade but hide the row visually. #}
+                                        <div class="form-group" style="display: none;">
+                                            <select class="form-control" name="region-filter"
+                                                empty-option="{{ adm_labels.region }}" style="width: 100%;" id="region-select-id">
+                                                <option value="{{ single_region.id }}" selected>{{ single_region.name }}</option>
+                                            </select>
+                                        </div>
+                                    {% else %}
+                                        <div class="form-group">
+                                            <label for="region-select-id">{{ adm_labels.region }}</label>
+                                            <select class="form-control" name="region-filter"
+                                                empty-option="{{ adm_labels.region }}" style="width: 100%;" id="region-select-id">
+                                                <option selected value="">{{ adm_labels.region }}</option>
+                                                {% for region in regions %}
+                                                    <option value="{{ region.id }}" {% if query_strings_raw|get_item:'region-filter' == region.id %}selected{% endif %}>{{ region.name }}</option>
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    {% endif %}
                                 </div>
                                 <div class="horizontal-form">
                                     <div class="form-group">
-                                        <label for="prefecture-select-id">{% translate 'Prefecture' %}</label>
+                                        <label for="prefecture-select-id">{{ adm_labels.prefecture }}</label>
                                         <select class="form-control" name="prefecture-filter" id="prefecture-select-id"
-                                        	empty-option="{% translate 'Prefecture' %}" style="width: 100%;" {% if not 'region-filter' in query_strings_raw %}disabled{% endif %}>
-                                            <option selected value="">{% translate 'Prefecture' %}</option>
+                                        	empty-option="{{ adm_labels.prefecture }}" style="width: 100%;" {% if not single_region and not 'region-filter' in query_strings_raw %}disabled{% endif %}>
+                                            <option selected value="">{{ adm_labels.prefecture }}</option>
                                             {% for prefecture in prefectures %}
                                                 <option value="{{ prefecture.id }}" {% if query_strings_raw|get_item:'prefecture-filter' == prefecture.id %}selected{% endif %}>{{ prefecture.name }}</option>
                                             {% endfor %}
                                         </select>
                                     </div>
                                     <div class="form-group">
-                                        <label for="commune-select-id">{% translate 'Commune' %}</label>
+                                        <label for="commune-select-id">{{ adm_labels.commune }}</label>
                                         <select class="form-control" name="commune-filter" id="commune-select-id"
-                                        	empty-option="{% translate 'Commune' %}" style="width: 100%;" {% if not 'prefecture-filter' in query_strings_raw %}disabled{% endif %}>
-                                            <option selected value="">{% translate 'Commune' %}</option>
+                                        	empty-option="{{ adm_labels.commune }}" style="width: 100%;" {% if not 'prefecture-filter' in query_strings_raw %}disabled{% endif %}>
+                                            <option selected value="">{{ adm_labels.commune }}</option>
                                             {% for commune in communes %}
                                                 <option value="{{ commune.id }}" {% if query_strings_raw|get_item:'commune-filter' == commune.id %}selected{% endif %}>{{ commune.name }}</option>
                                             {% endfor %}
                                         </select>
                                     </div>
                                     <div class="form-group">
-                                        <label for="canton-select-id">{% translate 'Canton' %}</label>
+                                        <label for="canton-select-id">{{ adm_labels.canton }}</label>
                                         <select class="form-control" name="canton-filter" id="canton-select-id"
-                                        	empty-option="{% translate 'Canton' %}" style="width: 100%;" {% if not 'commune-filter' in query_strings_raw %}disabled{% endif %}>
-                                            <option selected value="">{% translate 'Canton' %}</option>
+                                        	empty-option="{{ adm_labels.canton }}" style="width: 100%;" {% if not 'commune-filter' in query_strings_raw %}disabled{% endif %}>
+                                            <option selected value="">{{ adm_labels.canton }}</option>
                                             {% for canton in cantons %}
                                                 <option value="{{ canton.id }}" {% if query_strings_raw|get_item:'canton-filter' == canton.id %}selected{% endif %}>{{ canton.name }}</option>
                                             {% endfor %}
                                         </select>
                                     </div>
                                     <div class="form-group">
-                                        <label for="village-select-id">{% translate 'Village' %}</label>
+                                        <label for="village-select-id">{{ adm_labels.village }}</label>
                                         <select class="form-control" name="village-filter" id="village-select-id"
-                                        	empty-option="{% translate 'Village' %}" style="width: 100%;" {% if not 'canton-filter' in query_strings_raw %}disabled{% endif %}>
-                                            <option selected value="">{% translate 'Village' %}</option>
+                                        	empty-option="{{ adm_labels.village }}" style="width: 100%;" {% if not 'canton-filter' in query_strings_raw %}disabled{% endif %}>
+                                            <option selected value="">{{ adm_labels.village }}</option>
                                             {% for village in villages %}
                                                 <option value="{{ village.id }}" {% if query_strings_raw|get_item:'village-filter' == village.id %}selected{% endif %}>{{ village.name }}</option>
                                             {% endfor %}

--- a/cosomis/dashboard/views_summary.py
+++ b/cosomis/dashboard/views_summary.py
@@ -29,9 +29,16 @@ class DashboardSummaryView(LoginRequiredApproveRequiredMixin, generic.TemplateVi
         filters_context = {}
         adm_queryset = AdministrativeLevel.objects.all()
 
-        filters_context["regions"] = adm_queryset.filter(
+        regions_qs = adm_queryset.filter(
             AdministrativeLevel.type_filter_q(AdministrativeLevel.REGION)
         )
+        filters_context["regions"] = regions_qs
+        # Hide the top-level dropdown when the dataset has a single root and
+        # pre-load its prefectures so the cascade starts one level deeper.
+        single_region = regions_qs.first() if regions_qs.count() == 1 else None
+        filters_context["single_region"] = single_region
+        filters_context["adm_labels"] = AdministrativeLevel.get_filter_labels()
+
         filters_context["prefectures"] = adm_queryset.filter(
             AdministrativeLevel.type_filter_q(AdministrativeLevel.PREFECTURE)
         )
@@ -48,9 +55,12 @@ class DashboardSummaryView(LoginRequiredApproveRequiredMixin, generic.TemplateVi
         filters_context["sectors"] = Category.objects.all()
         filters_context["types"] = Investment.INVESTMENT_STATUS_CHOICES
 
-        if "region-filter" in self.request.GET:
+        region_filter_id = self.request.GET.get("region-filter") or (
+            str(single_region.id) if single_region else None
+        )
+        if region_filter_id:
             filters_context["prefectures"] = filters_context["prefectures"].filter(
-                parent__id=self.request.GET["region-filter"]
+                parent__id=region_filter_id
             )
 
         if "prefecture-filter" in self.request.GET:

--- a/cosomis/investments/templates/investments/list.html
+++ b/cosomis/investments/templates/investments/list.html
@@ -774,70 +774,39 @@
                         <div class="row">
                             <div class="col-9">
                                 <div class="row">
-                                    <div class="col-4">
-                                        <div class="form-group">
-                                            <label for="region-select-id">{% translate 'Region' %}</label>
-                                            <select class="form-control" name="region-filter" empty-option="{% translate 'Region' %}" style="width: 100%;" id="region-select-id">
-                                                <option selected value="">{% translate 'Region' %}</option>
-                                                {% for region in regions %}
-                                                    {% if 'region-filter' in query_strings_raw %}
-                                                        {% if query_strings_raw|get_item:'region-filter' == region.id %}
-                                                        <option value="{{ region.id }}" selected>{{ region.name }}</option>
-                                                        {% else %}
-                                                        <option value="{{ region.id }}">{{ region.name }}</option>
-                                                        {% endif %}
-                                                    {% else %}
-                                                        <option value="{{ region.id }}">{{ region.name }}</option>
-                                                    {% endif %}
-                                                {% endfor %}
+                                    {% if single_region %}
+                                        {# Single-root dataset: keep the select in the DOM for the JS cascade but visually hide the column. #}
+                                        <div class="col-4" style="display: none;">
+                                            <select class="form-control" name="region-filter" empty-option="{{ adm_labels.region }}" style="width: 100%;" id="region-select-id">
+                                                <option value="{{ single_region.id }}" selected>{{ single_region.name }}</option>
                                             </select>
                                         </div>
-                                    </div>
-                                    <div class="col-4">
-                                        <div class="form-group">
-                                            <label for="commune-select-id">{% translate 'Commune' %}</label>
-                                            <select class="form-control" name="commune-filter" id="commune-select-id" empty-option="{% translate 'Commune' %}" style="width: 100%;" {% if not 'prefecture-filter' in query_strings_raw %}disabled{% endif %}>
-                                                <option selected value="">{% translate 'Commune' %}</option>
-                                                {% for commune in communes %}
-                                                    {% if 'commune-filter' in query_strings_raw %}
-                                                        {% if query_strings_raw|get_item:'commune-filter' == commune.id %}
-                                                        <option value="{{ commune.id }}" selected>{{ commune.name }}</option>
+                                    {% else %}
+                                        <div class="col-4">
+                                            <div class="form-group">
+                                                <label for="region-select-id">{{ adm_labels.region }}</label>
+                                                <select class="form-control" name="region-filter" empty-option="{{ adm_labels.region }}" style="width: 100%;" id="region-select-id">
+                                                    <option selected value="">{{ adm_labels.region }}</option>
+                                                    {% for region in regions %}
+                                                        {% if 'region-filter' in query_strings_raw %}
+                                                            {% if query_strings_raw|get_item:'region-filter' == region.id %}
+                                                            <option value="{{ region.id }}" selected>{{ region.name }}</option>
+                                                            {% else %}
+                                                            <option value="{{ region.id }}">{{ region.name }}</option>
+                                                            {% endif %}
                                                         {% else %}
-                                                        <option value="{{ commune.id }}">{{ commune.name }}</option>
+                                                            <option value="{{ region.id }}">{{ region.name }}</option>
                                                         {% endif %}
-                                                    {% else %}
-                                                        <option value="{{ commune.id }}">{{ commune.name }}</option>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </select>
+                                                    {% endfor %}
+                                                </select>
+                                            </div>
                                         </div>
-                                    </div>
+                                    {% endif %}
                                     <div class="col-4">
                                         <div class="form-group">
-                                            <label for="village-select-id">{% translate 'Village' %}</label>
-                                            <select class="form-control" name="village-filter" id="village-select-id" empty-option="{% translate 'Village' %}" style="width: 100%;" {% if not 'canton-filter' in query_strings_raw %}disabled{% endif %}>
-                                                <option selected value="">{% translate 'Village' %}</option>
-                                                {% for village in villages %}
-                                                    {% if 'village-filter' in query_strings_raw %}
-                                                        {% if query_strings_raw|get_item:'village-filter' == village.id %}
-                                                        <option value="{{ village.id }}" selected>{{ village.name }}</option>
-                                                        {% else %}
-                                                        <option value="{{ village.id }}">{{ village.name }}</option>
-                                                        {% endif %}
-                                                    {% else %}
-                                                        <option value="{{ village.id }}">{{ village.name }}</option>
-                                                    {% endif %}
-                                                {% endfor %}
-                                            </select>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col-4">
-                                        <div class="form-group">
-                                            <label for="prefecture-select-id">{% translate 'Prefecture' %}</label>
-                                            <select class="form-control" name="prefecture-filter" id="prefecture-select-id" empty-option="{% translate 'Prefecture' %}" style="width: 100%;" {% if not 'region-filter' in query_strings_raw %}disabled{% endif %}>
-                                                <option selected value="">{% translate 'Prefecture' %}</option>
+                                            <label for="prefecture-select-id">{{ adm_labels.prefecture }}</label>
+                                            <select class="form-control" name="prefecture-filter" id="prefecture-select-id" empty-option="{{ adm_labels.prefecture }}" style="width: 100%;" {% if not single_region and not 'region-filter' in query_strings_raw %}disabled{% endif %}>
+                                                <option selected value="">{{ adm_labels.prefecture }}</option>
                                                 {% for prefecture in prefectures %}
                                                     {% if 'prefecture-filter' in query_strings_raw %}
                                                         {% if query_strings_raw|get_item:'prefecture-filter' == prefecture.id %}
@@ -854,9 +823,30 @@
                                     </div>
                                     <div class="col-4">
                                         <div class="form-group">
-                                            <label for="canton-select-id">{% translate 'Canton' %}</label>
-                                            <select class="form-control" name="canton-filter" id="canton-select-id" empty-option="{% translate 'Canton' %}" style="width: 100%;" {% if not 'commune-filter' in query_strings_raw %}disabled{% endif %}>
-                                                <option selected value="">{% translate 'Canton' %}</option>
+                                            <label for="commune-select-id">{{ adm_labels.commune }}</label>
+                                            <select class="form-control" name="commune-filter" id="commune-select-id" empty-option="{{ adm_labels.commune }}" style="width: 100%;" {% if not 'prefecture-filter' in query_strings_raw %}disabled{% endif %}>
+                                                <option selected value="">{{ adm_labels.commune }}</option>
+                                                {% for commune in communes %}
+                                                    {% if 'commune-filter' in query_strings_raw %}
+                                                        {% if query_strings_raw|get_item:'commune-filter' == commune.id %}
+                                                        <option value="{{ commune.id }}" selected>{{ commune.name }}</option>
+                                                        {% else %}
+                                                        <option value="{{ commune.id }}">{{ commune.name }}</option>
+                                                        {% endif %}
+                                                    {% else %}
+                                                        <option value="{{ commune.id }}">{{ commune.name }}</option>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-4">
+                                        <div class="form-group">
+                                            <label for="canton-select-id">{{ adm_labels.canton }}</label>
+                                            <select class="form-control" name="canton-filter" id="canton-select-id" empty-option="{{ adm_labels.canton }}" style="width: 100%;" {% if not 'commune-filter' in query_strings_raw %}disabled{% endif %}>
+                                                <option selected value="">{{ adm_labels.canton }}</option>
                                                 {% for canton in cantons %}
                                                     {% if 'canton-filter' in query_strings_raw %}
                                                         {% if query_strings_raw|get_item:'canton-filter' == canton.id %}
@@ -866,6 +856,25 @@
                                                         {% endif %}
                                                     {% else %}
                                                         <option value="{{ canton.id }}">{{ canton.name }}</option>
+                                                    {% endif %}
+                                                {% endfor %}
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div class="col-4">
+                                        <div class="form-group">
+                                            <label for="village-select-id">{{ adm_labels.village }}</label>
+                                            <select class="form-control" name="village-filter" id="village-select-id" empty-option="{{ adm_labels.village }}" style="width: 100%;" {% if not 'canton-filter' in query_strings_raw %}disabled{% endif %}>
+                                                <option selected value="">{{ adm_labels.village }}</option>
+                                                {% for village in villages %}
+                                                    {% if 'village-filter' in query_strings_raw %}
+                                                        {% if query_strings_raw|get_item:'village-filter' == village.id %}
+                                                        <option value="{{ village.id }}" selected>{{ village.name }}</option>
+                                                        {% else %}
+                                                        <option value="{{ village.id }}">{{ village.name }}</option>
+                                                        {% endif %}
+                                                    {% else %}
+                                                        <option value="{{ village.id }}">{{ village.name }}</option>
                                                     {% endif %}
                                                 {% endfor %}
                                             </select>
@@ -1078,24 +1087,24 @@
                                     <div class="custom-control custom-switch">
                                         <input checked class="custom-control-input column-switch"
                                                data-column="4" id="customSwitchVillage" type="checkbox">
-                                        <label class="custom-control-label" for="customSwitchVillage">{% translate 'Village' %}</label>
+                                        <label class="custom-control-label" for="customSwitchVillage">{{ adm_labels.village }}</label>
                                     </div>
                                     <div class="custom-control custom-switch">
                                         <input checked class="custom-control-input column-switch"
                                                data-column="5" id="customSwitchCommunity" type="checkbox">
-                                        <label class="custom-control-label" for="customSwitchCommunity">{% translate 'Commune' %}</label>
+                                        <label class="custom-control-label" for="customSwitchCommunity">{{ adm_labels.commune }}</label>
                                     </div>
                                     <div class="custom-control custom-switch">
                                         <input checked class="custom-control-input column-switch"
                                                data-column="6" id="customSwitchPrefecture" type="checkbox">
-                                        <label class="custom-control-label" for="customSwitchPrefecture">{% translate 'Prefecture' %}</label>
+                                        <label class="custom-control-label" for="customSwitchPrefecture">{{ adm_labels.prefecture }}</label>
                                     </div>
                                 </div>
                                 <div class="col-4">
                                     <div class="custom-control custom-switch">
                                         <input checked class="custom-control-input column-switch"
                                                data-column="7" id="customSwitchRegion" type="checkbox">
-                                        <label class="custom-control-label" for="customSwitchRegion">{% translate 'Region' %}</label>
+                                        <label class="custom-control-label" for="customSwitchRegion">{{ adm_labels.region }}</label>
                                     </div>
                                     <div class="custom-control custom-switch">
                                         <input checked class="custom-control-input column-switch"
@@ -1265,10 +1274,10 @@
                                 <th data-priority="2" class="align-middle">{% translate 'Name' %}</th>
                                 <th data-priority="3" class="align-middle">{% translate 'Source' %}</th>
                                 <th data-priority="4" class="align-middle">{% translate 'Estimate cost' %}</th>
-                                <th data-priority="5" class="align-middle">{% translate 'Village' %}</th>
-                                <th data-priority="6" class="align-middle">{% translate 'Canton' %}</th>
-                                <th data-priority="7" class="align-middle">{% translate 'Commune' %}</th>
-                                <th data-priority="8" class="align-middle">{% translate 'Prefecture' %}</th>
+                                <th data-priority="5" class="align-middle">{{ adm_labels.village }}</th>
+                                <th data-priority="6" class="align-middle">{{ adm_labels.canton }}</th>
+                                <th data-priority="7" class="align-middle">{{ adm_labels.commune }}</th>
+                                <th data-priority="8" class="align-middle">{{ adm_labels.prefecture }}</th>
                                 <th data-priority="9" class="align-middle">{% translate 'Village priority' %}</th>
                                 <th data-priority="10" class="align-middle">{% translate 'Population priority' %}</th>
                             </thead>

--- a/cosomis/investments/views.py
+++ b/cosomis/investments/views.py
@@ -120,31 +120,49 @@ class IndexListView(
 
     def get_context_data(self, **kwargs):
         adm_queryset = AdministrativeLevel.objects.all()
-        kwargs["regions"] = adm_queryset.filter(type=AdministrativeLevel.REGION)
+        regions_qs = adm_queryset.filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.REGION)
+        )
+        kwargs["regions"] = regions_qs
 
-        kwargs["prefectures"] = adm_queryset.filter(type=AdministrativeLevel.PREFECTURE)
-        if "region-filter" in self.request.GET:
-            kwargs["prefectures"] = kwargs["prefectures"].filter(
-                parent__id=self.request.GET["region-filter"]
-            )
+        # When the dataset has a single root (Benin = one "country" row), hide
+        # the top-level select and treat that root as implicitly selected so
+        # the prefecture dropdown starts pre-loaded.
+        single_region = regions_qs.first() if regions_qs.count() == 1 else None
+        kwargs["single_region"] = single_region
+        kwargs["adm_labels"] = AdministrativeLevel.get_filter_labels()
 
-        kwargs["communes"] = adm_queryset.filter(type=AdministrativeLevel.COMMUNE)
+        region_filter_id = self.request.GET.get("region-filter") or (
+            str(single_region.id) if single_region else None
+        )
+
+        prefectures_qs = adm_queryset.filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.PREFECTURE)
+        )
+        if region_filter_id:
+            prefectures_qs = prefectures_qs.filter(parent__id=region_filter_id)
+        kwargs["prefectures"] = prefectures_qs
+
+        communes_qs = adm_queryset.filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.COMMUNE)
+        )
         if "prefecture-filter" in self.request.GET:
-            kwargs["communes"] = kwargs["communes"].filter(
-                parent__id=self.request.GET["prefecture-filter"]
-            )
+            communes_qs = communes_qs.filter(parent__id=self.request.GET["prefecture-filter"])
+        kwargs["communes"] = communes_qs
 
-        kwargs["cantons"] = adm_queryset.filter(type=AdministrativeLevel.CANTON)
+        cantons_qs = adm_queryset.filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.CANTON)
+        )
         if "commune-filter" in self.request.GET:
-            kwargs["cantons"] = kwargs["cantons"].filter(
-                parent__id=self.request.GET["commune-filter"]
-            )
+            cantons_qs = cantons_qs.filter(parent__id=self.request.GET["commune-filter"])
+        kwargs["cantons"] = cantons_qs
 
-        kwargs["villages"] = adm_queryset.filter(type=AdministrativeLevel.VILLAGE)
+        villages_qs = adm_queryset.filter(
+            AdministrativeLevel.type_filter_q(AdministrativeLevel.VILLAGE)
+        )
         if "cantons-filter" in self.request.GET:
-            kwargs["villages"] = kwargs["villages"].filter(
-                parent__id=self.request.GET["cantons-filter"]
-            )
+            villages_qs = villages_qs.filter(parent__id=self.request.GET["cantons-filter"])
+        kwargs["villages"] = villages_qs
 
         kwargs["categories"] = Category.objects.all()
         if "category-filter" in self.request.GET:


### PR DESCRIPTION
## Summary

- Make the admin-level filter UIs (Gallery, Investments, Dashboard summary, Administrative-levels search) render labels from the dataset's own vocabulary — `Country / Département / Commune / Arrondissement / Village` on Benin, `Region / Prefecture / Commune / Canton / Village` on Togo — instead of hard-coded Togo strings.
- On single-root datasets (Benin has one `country` row at the top), hide the redundant top-level dropdown and pre-load its direct children into the next level so the cascade starts one step deeper.
- Migrate the remaining `type=AdministrativeLevel.X` exact-match filters to `AdministrativeLevel.type_filter_q(X)`, the alias-aware helper that CLAUDE.md flags as the supported pattern. Without this, Benin's `country / département / arrondissement` rows were silently filtered out, leaving dropdowns empty.
- Reorder the Investments page admin dropdowns to flow hierarchically top-down (Region → Prefecture → Commune → Canton → Village) instead of the previous zig-zag layout.

## What changed

**Shared helper** — [administrativelevels/models.py](cosomis/administrativelevels/models.py)
- New classmethod `AdministrativeLevel.get_filter_labels()` returns the `{canonical_key: display_label}` mapping, sourcing labels from `get_hierarchy_labels()` and falling back to translated English when the dataset has fewer than 5 levels. Used by every filter UI below.

**Gallery** — [administrativelevels/views.py](cosomis/administrativelevels/views.py), [administrativelevels/utils/views.py](cosomis/administrativelevels/utils/views.py), [administrativelevels/forms.py](cosomis/administrativelevels/forms.py), [administrativelevels/templates/attachments/attachments.html](cosomis/administrativelevels/templates/attachments/attachments.html)
- `AttachmentListView` exposes `adm_labels` + `single_region` to the template, pre-fetches prefectures of the single root, and skips the redundant `Country: BENIN` chip in the active-filter chip builder.
- `FillAttachmentSelectFilters` AJAX endpoint replaces all 5 `.filter(type=AdministrativeLevel.X)` calls with `type_filter_q(X)` so the cascade works on Benin.
- `AttachmentFilterForm.administrative_level` queryset migrated to `type_filter_q(VILLAGE)`.
- Modal template: 5 visible labels read from `adm_labels.*`; region row rendered `display:none` with the single value pre-selected when `single_region`.

**Investments** — [investments/views.py](cosomis/investments/views.py), [investments/templates/investments/list.html](cosomis/investments/templates/investments/list.html)
- `IndexListView` migrates all 5 admin-level filter querysets to `type_filter_q`, detects `single_region`, pre-filters the prefecture queryset when no explicit `region-filter` in URL.
- Template:
  - 5 admin-level dropdown labels + `empty-option` attributes + placeholder `<option>` texts all read from `adm_labels.*` (15 swaps).
  - 4 column-toggle checkbox labels (Village / Commune / Prefecture / Region) and 4 DataTables header cells (Village / Canton / Commune / Prefecture) relabeled.
  - Region column rendered `display:none` (select stays in DOM so `#region-select-id` is still bindable by the cascade JS) when `single_region`.
  - Dropdowns reordered: Region → Prefecture → Commune (row 1) → Canton → Village (row 2).

**Dashboard summary** — [dashboard/views_summary.py](cosomis/dashboard/views_summary.py), [dashboard/templates/dashboard_summary.html](cosomis/dashboard/templates/dashboard_summary.html)
- View exposes `adm_labels` + `single_region`, pre-filters prefectures when single-root.
- Template: 5 admin-level dropdown labels (×3 sites each) read from `adm_labels.*`; region form-group hidden + select kept in DOM; prefecture `disabled` flag respects `single_region`.

**Administrative-levels search** — [administrativelevels/views.py](cosomis/administrativelevels/views.py), [administrativelevels/forms.py](cosomis/administrativelevels/forms.py), [administrativelevels/templates/administrative_level/list.html](cosomis/administrativelevels/templates/administrative_level/list.html)
- View detects `single_region` from `parent__isnull=True` roots and passes it to the form with `initial={'region': single_region}`.
- `VillageSearchForm.__init__` accepts a `single_region` kwarg and pre-loads the prefecture queryset with its direct children.
- Template: the region row in the form `for`-loop gets `style="display:none"` when single-root; JS init excludes `id_prefecture` from the disable-all-non-region sweep so it's usable from the start.

## Test plan

- [ ] Load `/en/administrative-levels/attachments/?type=Photo` on Benin → modal opens with `Département / Commune / Arrondissement / Village` labels, Région row hidden, Département pre-populated with 4 départements. Pick one → Commune populates via AJAX. Apply filter → URL gains query params, gallery shrinks. No `Country: BENIN` chip.
- [ ] Load `/en/investments/` on Benin → filter card reads `Département / Commune / Arrondissement / Village` top-down hierarchical layout, Région column hidden, Département pre-loaded. Column-toggle card shows `Country / Département / Commune / Village`. DataTable header reads `Département / Commune / Arrondissement / Village`.
- [ ] Load `/en/dashboard/dashboard-summary/` on Benin → row of 4 admin-level dropdowns reads `Département / Commune / Arrondissement / Village`, Région absent.
- [ ] Load `/en/administrative-levels/search/` on Benin → only 3 visible dropdowns (Département / Commune / Arrondissement), Département pre-populated, search still works.
- [ ] Verify Togo (multi-region dataset): every page still renders `Région / Préfecture / Commune / Canton / Village` and the Région dropdown is visible. Cascade still walks correctly.
- [ ] `python manage.py check` passes (verified locally — System check identified no issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)