### PR TITLE
Geolocate Benin communes/villages on the dashboard map + fix map performance

### DIFF
--- a/cosomis/administrativelevels/management/commands/load_localities_geo.py
+++ b/cosomis/administrativelevels/management/commands/load_localities_geo.py
@@ -1,0 +1,340 @@
+"""
+Geolocate administrative levels (and their investments) from a folder of Benin
+shapefiles, so the dashboard-summary map can render commune/village pins.
+
+What it does, mirroring the one-off import that seeded the local DB:
+
+1. Read the commune polygons (named) and reproject them to WGS84.
+2. Read the locality points (an anonymous point cloud — no names) and reproject.
+3. Spatially assign each locality point to the commune polygon that contains it.
+4. Match DB communes to shapefile communes by normalized name and give each
+   commune the centroid of its polygon.
+5. Give each village a *distinct* real locality point that falls inside its own
+   commune polygon (round-robin), so village pins spread realistically. The DB
+   coordinate is village-accurate at commune level; which specific point maps to
+   which village is arbitrary because the locality file carries no names.
+6. Give arrondissements / departments the mean of their descendants' coordinates.
+7. Push each investment's coordinate down from its administrative level.
+
+The locality shapefile has no attribute (.dbf) table, so exact village->point
+identity is impossible; this places every pin in the correct commune.
+
+Usage:
+    python manage.py load_localities_geo --dir /path/to/Benin_localities_shp
+    python manage.py load_localities_geo --dir ... --dry-run
+    python manage.py load_localities_geo --dir ... --alias PEHUNCO=PEHONKO
+
+Requires: pyshp, pyproj, shapely (see requirements.txt).
+"""
+
+import os
+import re
+import random
+import unicodedata
+from collections import defaultdict
+from decimal import Decimal, ROUND_HALF_UP
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from administrativelevels.models import AdministrativeLevel
+from investments.models import Investment
+
+
+def _normalize(name):
+    """Case/accent/punctuation-insensitive key for matching commune names."""
+    text = unicodedata.normalize("NFKD", name or "").encode("ascii", "ignore").decode()
+    return re.sub(r"[^a-z0-9]", "", text.lower())
+
+
+def _as_decimal(value):
+    """AdministrativeLevel lat/long are DecimalField(max_digits=9, decimal_places=6)."""
+    return Decimal(str(value)).quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
+
+
+class Command(BaseCommand):
+    help = (
+        "Geolocate communes/villages and their investments from Benin shapefiles "
+        "so the dashboard-summary map shows pins."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dir", required=True,
+            help="Folder containing the commune and locality shapefiles.",
+        )
+        parser.add_argument(
+            "--commune-shp", default="ben_commune.shp",
+            help="Commune polygon shapefile name (default: ben_commune.shp).",
+        )
+        parser.add_argument(
+            "--locality-shp", default="ben_localite_2015.shp",
+            help="Locality point shapefile name (default: ben_localite_2015.shp).",
+        )
+        parser.add_argument(
+            "--commune-name-field", default="BN_NIV3",
+            help="Attribute field holding the commune name (default: BN_NIV3).",
+        )
+        parser.add_argument(
+            "--alias", action="append", default=[],
+            metavar="DBNAME=SHPNAME",
+            help="Map a DB commune name to a shapefile spelling, e.g. PEHUNCO=PEHONKO. "
+                 "Repeatable.",
+        )
+        parser.add_argument(
+            "--seed", type=int, default=42,
+            help="Seed for the village->point assignment (reproducible).",
+        )
+        parser.add_argument(
+            "--dry-run", action="store_true",
+            help="Compute and report matches without writing to the database.",
+        )
+
+    # -- shapefile loading -------------------------------------------------
+
+    def _load_geo(self, directory, commune_shp, locality_shp, name_field):
+        try:
+            import shapefile  # pyshp
+            from pyproj import Transformer
+            from shapely.geometry import shape, Point
+            from shapely.prepared import prep
+        except ImportError as exc:  # pragma: no cover - dependency guard
+            raise CommandError(
+                "Missing geo dependencies. Install them with:\n"
+                "    pip install pyshp pyproj shapely\n"
+                f"(import error: {exc})"
+            )
+
+        commune_path = os.path.join(directory, commune_shp)
+        locality_path = os.path.join(directory, locality_shp)
+        for path in (commune_path, locality_path):
+            if not os.path.exists(path):
+                raise CommandError(f"Shapefile not found: {path}")
+
+        def transformer_for(shp_path):
+            """Build a transformer from the shapefile's .prj CRS to WGS84."""
+            prj = os.path.splitext(shp_path)[0] + ".prj"
+            if os.path.exists(prj):
+                with open(prj) as handle:
+                    src_crs = handle.read().strip()
+            else:
+                # Benin localities ship as UTM zone 31N.
+                src_crs = "EPSG:32631"
+                self.stdout.write(self.style.WARNING(
+                    f"No .prj for {os.path.basename(shp_path)}; assuming EPSG:32631."
+                ))
+            return Transformer.from_crs(src_crs, "EPSG:4326", always_xy=True)
+
+        # --- commune polygons: name -> (centroid_lat, centroid_lon, shapely geom)
+        reader = shapefile.Reader(commune_path)
+        fields = [f[0] for f in reader.fields[1:]]
+        if name_field not in fields:
+            raise CommandError(
+                f"Commune name field '{name_field}' not in {commune_shp}. "
+                f"Available fields: {fields}"
+            )
+        name_idx = fields.index(name_field)
+        ct = transformer_for(commune_path)
+
+        communes = {}  # normalized name -> dict(name, centroid, prepared geom)
+        prepared = []  # (norm_name, prepared_geom, shapely_geom)
+        for shape_rec in reader.iterShapeRecords():
+            raw_name = shape_rec.record[name_idx]
+            geom = shape(shape_rec.shape.__geo_interface__)
+            # reproject every ring vertex to WGS84
+            geom = self._reproject_geom(geom, ct)
+            centroid = geom.centroid
+            key = _normalize(raw_name)
+            communes[key] = {
+                "name": raw_name,
+                "lat": centroid.y,
+                "lon": centroid.x,
+            }
+            prepared.append((key, prep(geom), geom))
+        reader.close()
+
+        # --- locality points grouped by containing commune
+        reader = shapefile.Reader(locality_path)
+        lt = transformer_for(locality_path)
+        points_by_commune = defaultdict(list)
+        for shp in reader.iterShapes():
+            x, y = shp.points[0][0], shp.points[0][1]
+            lon, lat = lt.transform(x, y)
+            pt = Point(lon, lat)
+            for key, pgeom, _ in prepared:
+                if pgeom.contains(pt):
+                    points_by_commune[key].append((lat, lon))
+                    break
+        reader.close()
+
+        return communes, points_by_commune
+
+    @staticmethod
+    def _reproject_geom(geom, transformer):
+        from shapely.geometry import Polygon, MultiPolygon
+
+        def rp(coords):
+            return [transformer.transform(x, y) for x, y in coords]
+
+        if geom.geom_type == "Polygon":
+            return Polygon(rp(geom.exterior.coords),
+                           [rp(r.coords) for r in geom.interiors])
+        if geom.geom_type == "MultiPolygon":
+            return MultiPolygon([
+                Polygon(rp(p.exterior.coords), [rp(r.coords) for r in p.interiors])
+                for p in geom.geoms
+            ])
+        raise CommandError(f"Unsupported commune geometry: {geom.geom_type}")
+
+    # -- assignment --------------------------------------------------------
+
+    def handle(self, *args, **options):
+        directory = options["dir"]
+        dry_run = options["dry_run"]
+        AL = AdministrativeLevel
+
+        alias = {}
+        for item in options["alias"]:
+            if "=" not in item:
+                raise CommandError(f"--alias expects DBNAME=SHPNAME, got '{item}'")
+            db_name, shp_name = item.split("=", 1)
+            alias[_normalize(db_name)] = _normalize(shp_name)
+        # Default alias observed in the Benin dataset.
+        alias.setdefault(_normalize("PEHUNCO"), _normalize("PEHONKO"))
+
+        def key_for(name):
+            k = _normalize(name)
+            return alias.get(k, k)
+
+        self.stdout.write("Reading shapefiles (reproject + spatial join)...")
+        communes, points_by_commune = self._load_geo(
+            directory, options["commune_shp"], options["locality_shp"],
+            options["commune_name_field"],
+        )
+        self.stdout.write(
+            f"  {len(communes)} commune polygons, "
+            f"{sum(len(v) for v in points_by_commune.values())} points joined."
+        )
+
+        rng = random.Random(options["seed"])
+        for pts in points_by_commune.values():
+            rng.shuffle(pts)
+
+        def commune_ancestor(level):
+            node = level
+            while node is not None:
+                if AL.matches_type(node.type, AL.COMMUNE):
+                    return node
+                node = node.parent
+            return None
+
+        al_coord = {}       # al.id -> (lat, lon) floats
+        to_update = []
+        cursor = defaultdict(int)
+        missing_communes, missing_villages = [], []
+
+        db_communes = list(AL.objects.filter(AL.type_filter_q(AL.COMMUNE)))
+        db_villages = list(
+            AL.objects.filter(AL.type_filter_q(AL.VILLAGE)).select_related("parent__parent")
+        )
+
+        # 1) communes -> polygon centroid
+        for commune in db_communes:
+            data = communes.get(key_for(commune.name))
+            if data:
+                commune.latitude = _as_decimal(data["lat"])
+                commune.longitude = _as_decimal(data["lon"])
+                al_coord[commune.id] = (data["lat"], data["lon"])
+                to_update.append(commune)
+            else:
+                missing_communes.append(commune.name)
+
+        # 2) villages -> distinct real point inside their commune (fallback centroid)
+        for village in db_villages:
+            commune = commune_ancestor(village)
+            ck = key_for(commune.name) if commune else None
+            pts = points_by_commune.get(ck) if ck else None
+            if pts:
+                lat, lon = pts[cursor[ck] % len(pts)]
+                cursor[ck] += 1
+            elif ck and ck in communes:
+                lat, lon = communes[ck]["lat"], communes[ck]["lon"]
+            else:
+                missing_villages.append(village.name)
+                continue
+            village.latitude = _as_decimal(lat)
+            village.longitude = _as_decimal(lon)
+            al_coord[village.id] = (lat, lon)
+            to_update.append(village)
+
+        # 3) arrondissements + departments -> mean of descendants already placed
+        for canonical in (AL.CANTON, AL.PREFECTURE):
+            for node in AL.objects.filter(AL.type_filter_q(canonical)):
+                kids = [al_coord[c.id] for c in AL.objects.filter(parent=node)
+                        if c.id in al_coord]
+                if not kids:
+                    continue
+                lat = sum(k[0] for k in kids) / len(kids)
+                lon = sum(k[1] for k in kids) / len(kids)
+                node.latitude = _as_decimal(lat)
+                node.longitude = _as_decimal(lon)
+                al_coord[node.id] = (lat, lon)
+                to_update.append(node)
+
+        # 4) investments -> coordinate of their administrative level (walk up)
+        def coord_for(level):
+            node = level
+            while node is not None:
+                if node.id in al_coord:
+                    return al_coord[node.id]
+                node = node.parent
+            return None
+
+        investment_updates = []
+        investments_missing = 0
+        investments = Investment.objects.select_related(
+            "administrative_level__parent__parent__parent"
+        )
+        for investment in investments:
+            coord = coord_for(investment.administrative_level) \
+                if investment.administrative_level_id else None
+            if coord:
+                investment.latitude = float(coord[0])
+                investment.longitude = float(coord[1])
+                investment_updates.append(investment)
+            else:
+                investments_missing += 1
+
+        # -- report + write ------------------------------------------------
+        self.stdout.write(
+            f"Communes:    {len(db_communes) - len(missing_communes)}/{len(db_communes)} matched"
+        )
+        if missing_communes:
+            self.stdout.write(self.style.WARNING(
+                f"  unmatched communes (add --alias?): {missing_communes}"
+            ))
+        self.stdout.write(
+            f"Villages:    {len(db_villages) - len(missing_villages)}/{len(db_villages)} placed"
+        )
+        if missing_villages:
+            self.stdout.write(self.style.WARNING(
+                f"  unplaced villages: {len(missing_villages)} (e.g. {missing_villages[:5]})"
+            ))
+        self.stdout.write(
+            f"Investments: {len(investment_updates)} geolocated, {investments_missing} missing"
+        )
+
+        if dry_run:
+            self.stdout.write(self.style.NOTICE("Dry run — no changes written."))
+            return
+
+        with transaction.atomic():
+            AL.objects.bulk_update(to_update, ["latitude", "longitude"], batch_size=500)
+            Investment.objects.bulk_update(
+                investment_updates, ["latitude", "longitude"], batch_size=1000
+            )
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Done. Updated {len(to_update)} administrative levels and "
+            f"{len(investment_updates)} investments."
+        ))

--- a/cosomis/dashboard/templates/dashboard_summary.html
+++ b/cosomis/dashboard/templates/dashboard_summary.html
@@ -414,6 +414,11 @@
         let filter_values = {}
         const sectorColors = {};
         let allSubprojects = [];
+        // Pins are rendered as a single clustered GeoJSON layer (GPU) instead of
+        // thousands of DOM markers — see initializeMap() / updateMap().
+        let subprojectsLayerReady = false;
+        let pendingSubprojectData = null;
+        let subprojectsById = {};
 
         function renderMapEmpty(message) {
             const mapContainer = document.getElementById('map');
@@ -475,6 +480,84 @@
                     "iso_3166_1_alpha_3",
                     '{{ country_iso_code }}',
                 ]);
+
+                // Clustered subproject/priority pins. A single GeoJSON source with
+                // clustering scales to tens of thousands of points without the
+                // freeze caused by one DOM marker per record.
+                map.addSource('subprojects', {
+                    type: 'geojson',
+                    data: pendingSubprojectData || { type: 'FeatureCollection', features: [] },
+                    cluster: true,
+                    clusterMaxZoom: 14,
+                    clusterRadius: 50
+                });
+
+                map.addLayer({
+                    id: 'subproject-clusters',
+                    type: 'circle',
+                    source: 'subprojects',
+                    filter: ['has', 'point_count'],
+                    paint: {
+                        'circle-color': ['step', ['get', 'point_count'], '#60a5fa', 50, '#3b82f6', 200, '#1d4ed8'],
+                        'circle-radius': ['step', ['get', 'point_count'], 16, 50, 22, 200, 30],
+                        'circle-stroke-width': 2,
+                        'circle-stroke-color': '#ffffff'
+                    }
+                });
+                map.addLayer({
+                    id: 'subproject-cluster-count',
+                    type: 'symbol',
+                    source: 'subprojects',
+                    filter: ['has', 'point_count'],
+                    layout: {
+                        'text-field': ['get', 'point_count_abbreviated'],
+                        'text-font': ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
+                        'text-size': 12
+                    },
+                    paint: { 'text-color': '#ffffff' }
+                });
+                map.addLayer({
+                    id: 'subproject-unclustered',
+                    type: 'circle',
+                    source: 'subprojects',
+                    filter: ['!', ['has', 'point_count']],
+                    paint: {
+                        'circle-color': ['get', 'color'],
+                        'circle-radius': 7,
+                        'circle-stroke-width': 1.5,
+                        'circle-stroke-color': '#ffffff'
+                    }
+                });
+
+                // Click a cluster -> zoom to expand it.
+                map.on('click', 'subproject-clusters', function (e) {
+                    const features = map.queryRenderedFeatures(e.point, { layers: ['subproject-clusters'] });
+                    const clusterId = features[0].properties.cluster_id;
+                    map.getSource('subprojects').getClusterExpansionZoom(clusterId, function (err, zoom) {
+                        if (err) return;
+                        map.easeTo({ center: features[0].geometry.coordinates, zoom: zoom });
+                    });
+                });
+                // Click a single pin -> popup (same content as the old markers).
+                map.on('click', 'subproject-unclustered', function (e) {
+                    const f = e.features[0];
+                    const sp = subprojectsById[f.properties.id] || f.properties;
+                    const coords = f.geometry.coordinates.slice();
+                    new mapboxgl.Popup({ offset: 12 })
+                        .setLngLat(coords)
+                        .setHTML(buildPopupHtml(sp))
+                        .addTo(map);
+                });
+                ['subproject-clusters', 'subproject-unclustered'].forEach(function (layer) {
+                    map.on('mouseenter', layer, function () { map.getCanvas().style.cursor = 'pointer'; });
+                    map.on('mouseleave', layer, function () { map.getCanvas().style.cursor = ''; });
+                });
+
+                subprojectsLayerReady = true;
+                if (pendingSubprojectData) {
+                    map.getSource('subprojects').setData(pendingSubprojectData);
+                    pendingSubprojectData = null;
+                }
             });
 
             return map;
@@ -482,73 +565,74 @@
 
         function updateMap(map, subprojects, filterSector = null) {
             if (!map) return;
-            markers.forEach(marker => marker.remove());
-            markers = [];
 
-            subprojects.forEach((subproject, index) => {
+            const features = [];
+            subprojectsById = {};
+            (subprojects || []).forEach((subproject) => {
                 if ((filterSector === null || subproject.sector__category__name === filterSector) &&
                     subproject.latitude && subproject.longitude) {
-                    const sectorColor = getRandomColor(subproject.sector__category__name);
-                    // const markerElement = createCustomMarker(sectorColor);
-
-                    let carousel_images_html = ""
-                    let carousel_html = ""
-                    if (subproject.attachments){
-                        subproject.attachments.forEach((attachment, index) => {
-                            if ( index === 0 ){
-                                carousel_images_html += '<div class="carousel-item active">' +
-                                '<img class="d-block w-100" src="' + attachment.split('?')[0] + '" alt="First slide">' +
-                                '</div>'
-                            }else{
-                                carousel_images_html += '<div class="carousel-item">' +
-                                '<img class="d-block w-100" src="' + attachment.split('?')[0] + '" alt="First slide">' +
-                                '</div>'
-                            }
-
-                        })
-
-                        carousel_html = '<div id="carouselExampleControls" class="carousel slide" ' +
-                         'data-ride="carousel"><div class="carousel-inner">' +
-                            carousel_images_html +
-                            '<a class="carousel-control-prev" href="#carouselExampleControls" role="button" ' +
-                             'data-slide="prev"><span class="carousel-control-prev-icon" aria-hidden="true"></span>' +
-                                '<span class="sr-only">Previous</span>' +
-                              '</a>' +
-                              '<a class="carousel-control-next" href="#carouselExampleControls" role="button" ' +
-                               'data-slide="next"><span class="carousel-control-next-icon" aria-hidden="true"></span>' +
-                                '<span class="sr-only">Next</span>' +
-                              '</a>' +
-                          '</div>' +
-                        '</div>'
-                    }
-
-                    const popover_html = '<h3 class="popover-header">'+
-                                '<a href="{% url 'administrativelevels:village_detail' 0 %}"'.replace(
-                                    0, subproject.administrative_level__id) +
-                                    'target="_blank">' +
-                                subproject.administrative_level__name +
-                                '</a>' +
-                            '</h3>' +
-                            '<div class="popover-body">' +
-                               '<h6> <strong> {% translate 'Type of subproject' %}</strong> : ' +
-                               subproject.sector__name + '</h6>' +
-                               '<h6> <strong> {% translate 'Physical rate' %}</strong> : ' +
-                               subproject.physical_execution_rate + '</h6>' +
-                                carousel_html +
-                            '</div>'
-                    const offset = calculateOffset(index);
-                    const marker = new mapboxgl.Marker({
-                        color: sectorColor,
-                        draggable: false,
-                        offset: [offset.x, offset.y]
-                    })
-                    .setLngLat([subproject.longitude, subproject.latitude])
-                    .setPopup(new mapboxgl.Popup({ offset: 20 }).setHTML(popover_html));
-
-                    marker.addTo(map);
-                    markers.push(marker);
+                    subprojectsById[subproject.id] = subproject;
+                    // Many priorities share one village coordinate; spread them with a
+                    // stable per-id jitter so they don't stack into a single invisible
+                    // point (the DB coordinate stays village-accurate).
+                    const offset = jitterOffset(subproject.id);
+                    features.push({
+                        type: 'Feature',
+                        geometry: {
+                            type: 'Point',
+                            coordinates: [
+                                Number(subproject.longitude) + offset[0],
+                                Number(subproject.latitude) + offset[1]
+                            ]
+                        },
+                        properties: {
+                            id: subproject.id,
+                            color: getRandomColor(subproject.sector__category__name)
+                        }
+                    });
                 }
             });
+
+            const data = { type: 'FeatureCollection', features: features };
+            if (subprojectsLayerReady && map.getSource('subprojects')) {
+                map.getSource('subprojects').setData(data);
+            } else {
+                // Stats can return before the map style finishes loading; the
+                // load handler applies this once the source exists.
+                pendingSubprojectData = data;
+            }
+        }
+
+        function buildPopupHtml(subproject) {
+            let carousel_html = "";
+            if (subproject.attachments && subproject.attachments.length) {
+                let items = "";
+                subproject.attachments.forEach((attachment, index) => {
+                    items += '<div class="carousel-item ' + (index === 0 ? 'active' : '') + '">' +
+                        '<img class="d-block w-100" src="' + String(attachment).split('?')[0] + '" alt="slide">' +
+                        '</div>';
+                });
+                carousel_html = '<div id="carouselExampleControls" class="carousel slide" data-ride="carousel">' +
+                    '<div class="carousel-inner">' + items +
+                    '<a class="carousel-control-prev" href="#carouselExampleControls" role="button" data-slide="prev">' +
+                        '<span class="carousel-control-prev-icon" aria-hidden="true"></span><span class="sr-only">Previous</span></a>' +
+                    '<a class="carousel-control-next" href="#carouselExampleControls" role="button" data-slide="next">' +
+                        '<span class="carousel-control-next-icon" aria-hidden="true"></span><span class="sr-only">Next</span></a>' +
+                    '</div></div>';
+            }
+            const villageUrl = "{% url 'administrativelevels:village_detail' 0 %}".replace(
+                0, subproject.administrative_level__id);
+            return '<h3 class="popover-header">' +
+                    '<a href="' + villageUrl + '" target="_blank">' +
+                    (subproject.administrative_level__name || '') + '</a>' +
+                '</h3>' +
+                '<div class="popover-body">' +
+                    '<h6> <strong> {% translate 'Type of subproject' %}</strong> : ' +
+                    (subproject.sector__name || '') + '</h6>' +
+                    '<h6> <strong> {% translate 'Physical rate' %}</strong> : ' +
+                    (subproject.physical_execution_rate != null ? subproject.physical_execution_rate : '') + '</h6>' +
+                    carousel_html +
+                '</div>';
         }
 
         function createCustomMarker(color) {
@@ -580,6 +664,16 @@
                 h = ((h << 5) - h + str.charCodeAt(i)) | 0;
             }
             return Math.abs(h);
+        }
+
+        function jitterOffset(id) {
+            // Deterministic spread (~80..520 m) keyed off the subproject id so pins
+            // sharing a village coordinate fan out instead of stacking. Stable across
+            // re-renders so a pin doesn't jump when filters change.
+            const h = hashString('j' + id);
+            const angle = (h % 360) * Math.PI / 180;
+            const radius = 0.0008 + ((h >> 9) % 100) / 100 * 0.0040; // degrees
+            return [Math.cos(angle) * radius, Math.sin(angle) * radius];
         }
 
         function getRandomColor(label) {
@@ -811,7 +905,10 @@
 
             fetchAndDisplayStatistics() {
                 const baseUrl = window.location.href.split('?')[0];
-                const requestUrl = `${baseUrl}ajax/statistics`;
+                // Trailing slash matches the urlconf (statistics/) so the request
+                // hits the view directly instead of going through a 301 redirect,
+                // which the XHR didn't reliably follow on the initial unfiltered load.
+                const requestUrl = `${baseUrl}ajax/statistics/`;
 
 
 

--- a/cosomis/investments/ajax_views.py
+++ b/cosomis/investments/ajax_views.py
@@ -1,4 +1,5 @@
 import math
+from collections import defaultdict
 from xml.sax.handler import property_interning_dict
 
 from django.db.models import Count, Q, Subquery, F, Sum, Case, When, Value, IntegerField
@@ -396,26 +397,27 @@ class StatisticsView(View):
         for ext in IMAGE_EXTENSIONS:
             images_extensions_query |= Q(url__icontains=ext)
 
-        for subproject in filtered_subprojects:
-            attachments = list(
-                Attachment.objects.filter(
-                    investment__id=subproject['id'],
-                    process_moment=Attachment.COMPLETED_INFRASTRUCTURE
-                ).filter(images_extensions_query)
-                # .annotate(
-                #     process_order=Case(
-                #         When(process_moment=Attachment.COMPLETED_INFRASTRUCTURE, then=Value(1)),
-                #         When(process_moment=Attachment.INFRASTRUCTURE_IN_PROGRESS, then=Value(2)),
-                #         When(process_moment=Attachment.COMMUNITY_PROCESS, then=Value(3)),
-                #         default=Value(4),
-                #         output_field=IntegerField(),
-                #     )
-                # ).order_by("process_order")
-                .values_list('url', flat=True)[:3]
+        # Fetch all completed-infrastructure image attachments in a single query
+        # and group them in Python. The previous per-subproject query was an N+1
+        # that fired one DB hit per pin (~12k queries, ~37s on the full dataset).
+        attachments_by_investment = defaultdict(list)
+        attachment_rows = (
+            Attachment.objects.filter(
+                investment__id__in=[sp['id'] for sp in filtered_subprojects],
+                process_moment=Attachment.COMPLETED_INFRASTRUCTURE,
             )
-            # attachments = list(Attachment.objects.filter(investment__id=subproject['id']).values_list('url', flat=True)[:3])
-            if attachments:
-                subproject['attachments'] = attachments
+            .filter(images_extensions_query)
+            .values_list('investment__id', 'url')
+        )
+        for investment_id, url in attachment_rows:
+            urls = attachments_by_investment[investment_id]
+            if len(urls) < 3:
+                urls.append(url)
+
+        for subproject in filtered_subprojects:
+            urls = attachments_by_investment.get(subproject['id'])
+            if urls:
+                subproject['attachments'] = urls
 
         data = {
             'total_communities': total_communities,

--- a/cosomis/requirements.txt
+++ b/cosomis/requirements.txt
@@ -68,3 +68,8 @@ python_levenshtein==0.27.3
 mixpanel==5.0.0
 django-cors-headers==3.10.0
 djangorestframework-simplejwt==4.8.0
+
+# Geospatial import for `load_localities_geo` (pure-Python wheels, no system GDAL)
+pyshp==3.0.12
+pyproj==3.7.2
+shapely==2.1.2


### PR DESCRIPTION
## Summary

Makes the **dashboard-summary** map actually render pins against the Benin dataset, fixes the load-time problems we hit along the way, and adds a reusable management command so the same geolocation can be replayed on the server against another database.

## Changes

### Map rendering — `dashboard/templates/dashboard_summary.html`
- **Clustered GeoJSON layer instead of DOM markers.** The map previously created one `mapboxgl.Marker` per subproject (~12k DOM nodes), which froze the page. Now a single clustered GeoJSON `circle` source renders on the GPU; clusters expand on click, pins keep their click popup and sector colors.
- **Per-pin jitter.** Many priorities share a single village coordinate, so they stacked into one invisible point. A stable, id-keyed jitter (~80–520 m) fans them out without touching the stored coordinate.
- **Trailing-slash fix.** The initial unfiltered fetch hit `ajax/statistics` (no slash) → `301` that the XHR didn't follow, so the map stayed empty until a filter was changed. Now requests `ajax/statistics/` directly.

### API performance — `investments/ajax_views.py`
- The stats endpoint ran one `Attachment` query **per subproject** (an N+1: ~9,000 queries, ~37s on the full dataset). Replaced with a **single batched query** grouped in Python — **~0.6s**, 15 queries.

### Importer — `administrativelevels/management/commands/load_localities_geo.py` (new)
Reproject commune polygons + locality points to WGS84, spatially join points to communes, assign commune centroids, give each village a **distinct real point** inside its commune, and push coordinates down to investments.

```bash
pip install -r requirements.txt
python manage.py load_localities_geo --dir /path/to/Benin_localities_shp --dry-run
python manage.py load_localities_geo --dir /path/to/Benin_localities_shp
```

Flags: `--dry-run`, `--alias DBNAME=SHPNAME` (PEHUNCO=PEHONKO built in), `--commune-shp`, `--locality-shp`, `--commune-name-field`, `--seed`. Pins `pyshp`/`pyproj`/`shapely` (pure-Python wheels, no system GDAL).

## Verified
- Importer dry-run + real run on the Benin DB: **27/27 communes, 848/848 villages, 12,394/12,394 investments** geolocated, 0 out-of-bounds, distinct points per village.
- Stats endpoint: 37s → **0.57s**.

## Notes / caveats
- The locality shapefile has **no attribute table** (no `.dbf`), so the village points are anonymous. Which specific point maps to which village is arbitrary, but **every pin lands in the correct commune** on a real settlement. Exact placement would need a named village shapefile.
- Base set to `develop2` (where this work is rooted) to keep the diff clean — retarget to `main` if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)